### PR TITLE
feat(seasons): introduce season system with isolated coins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,37 @@ KBO 야구 승부예측 앱(ToKHin')을 LMSR 기반 예측시장으로 전환하
 - API 함수는 `lib/api.ts`에 집중
 - 새 페이지는 `app/` 디렉토리 내 폴더 기반 라우팅
 - 에러 메시지는 한국어
+
+## Season System (US-012)
+
+ToKHin' 은 시즌 단위로 코인이 격리된다. 각 시즌은 독립된 잔고/거래/포지션을 갖고, 시즌이 바뀌면 이전 시즌은 보관(ARCHIVED) 상태로 잠긴다.
+
+### Tables
+- `seasons(id, name, start_date, end_date, status)` — `status IN ('DRAFT','ACTIVE','ARCHIVED')`
+  - partial unique index: ACTIVE 1개, DRAFT 1개만 허용
+- `wallets`, `markets`, `orders`, `positions`, `transactions` — 전부 `season_id NOT NULL` FK 추가
+- `wallets` UNIQUE 제약: `(user_id, season_id)` → 사용자당 시즌별 지갑 1개
+
+### Initial seeded seasons
+- Season 0 (id=0, ARCHIVED): ~2026-03-27 — 레거시 데이터 버킷
+- Season 1 (id=1, ACTIVE): 2026-03-28 ~ — 현재 활성
+- Season 2 (id=2, DRAFT): 2026-05-19 ~ 2026-06-21 — 관리자가 수동 활성화 대기
+
+### Lifecycle (admin-controlled)
+1. **CREATE** → `create_season(name, start, end)` 으로 DRAFT 생성 (DRAFT 동시 1개만)
+2. **ACTIVATE** → `activate_season(id)` 호출. 이전 ACTIVE 시즌에 미정산(OPEN/CLOSED) 마켓이 있으면 차단. 성공 시: 이전 시즌 ARCHIVED + 새 시즌 ACTIVE + 전 사용자에게 1000코인 SEASON_GRANT 발행
+3. **END** → `end_season(id)` 로 명시적 종료 (활성→보관). 다음 시즌 activate 시 자동 종료도 가능
+
+### Rules
+- 모든 거래/정산은 active 시즌에서만 가능. 마켓의 `season_id`가 active와 다르면 RPC가 `'이 시즌은 더 이상 거래할 수 없습니다'` 로 차단
+- 신규 마켓 생성 시 자동으로 active 시즌의 id 부여 (`create_market` 내부에서 lookup)
+- 신규 회원가입 시 active 시즌의 지갑 자동 생성 (1000코인 + SEASON_GRANT 트랜잭션)
+- 리더보드/히스토리는 시즌별 조회 가능. 메인 페이지는 active 시즌 마켓만 노출
+- 마켓 상세에서 archived 시즌 마켓은 read-only (포지션은 표시, 거래 UI는 banner로 대체)
+
+### Transaction types
+`BUY, SELL, SETTLEMENT, WEEKLY_GRANT, ADMIN_GRANT, SEASON_GRANT` — SEASON_GRANT는 시즌 시작 시 일괄 지급
+
+### Migrations
+- `20260518000000_us_seasons_schema.sql` — 테이블, 컬럼, 백필, UNIQUE swap, SEASON_GRANT 합성
+- `20260518000001_us_seasons_rpcs.sql` — 시즌 라이프사이클 RPC 5개 + 기존 RPC 17개 시즌-인식 업데이트

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Please file feedback and issues over on the [Supabase GitHub org](https://github
 - [Cookie-based Auth and the Next.js 13 App Router (free course)](https://youtube.com/playlist?list=PL5S4mPUpp4OtMhpnp93EFSo42iQ40XjbF)
 - [Supabase Auth and the Next.js App Router](https://github.com/supabase/supabase/tree/master/examples/auth/nextjs)
 
-## 시즌 바꾸는 법
+## 시즌 관리
 
-`app/leaderboard/page.tsx`에서 `await getLeaderboard();` 함수 안의 시작 날짜와 종료 날짜를 수정만 하면 됩니다!
+시즌 시스템이 데이터베이스 레벨에서 구현되어 있습니다 (US-012).
+
+- **시즌 조회**: `/leaderboard` 페이지의 시즌 드롭다운에서 과거/현재 시즌 순위 조회 가능
+- **시즌 생성 및 활성화**: `/admin` → "시즌 관리" 카드에서 새 시즌 생성(DRAFT) → "시즌 시작" 버튼으로 활성화
+  - 이전 시즌에 정산되지 않은 마켓이 있으면 활성화가 차단됩니다 (한국어 에러로 안내)
+  - 활성화 시 전체 사용자에게 1000코인 자동 지급
+- **상세 동작**: `AGENTS.md`의 "Season System (US-012)" 섹션 참고

--- a/app/admin/SeasonManagement.tsx
+++ b/app/admin/SeasonManagement.tsx
@@ -1,0 +1,553 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { useIsMobile } from "@/lib/hooks/useResponsive";
+import {
+  getActiveSeason,
+  listSeasons,
+  createSeason,
+  activateSeason,
+  endSeason,
+  type Season,
+  type SeasonStatus,
+} from "@/lib/api";
+
+type Message = { type: "success" | "error"; text: string };
+
+const formatPeriod = (start: string | null, end: string | null) => {
+  if (!start && !end) return "기간 미정";
+  return `${start ?? "?"} ~ ${end ?? "?"}`;
+};
+
+const statusBadgeClass = (status: SeasonStatus): string => {
+  switch (status) {
+    case "ACTIVE":
+      return "bg-green-100 text-green-800";
+    case "DRAFT":
+      return "bg-gray-100 text-gray-700";
+    case "ARCHIVED":
+      return "bg-zinc-200 text-zinc-600";
+    default:
+      return "bg-gray-100 text-gray-700";
+  }
+};
+
+const statusLabel = (status: SeasonStatus): string => {
+  switch (status) {
+    case "ACTIVE":
+      return "진행중";
+    case "DRAFT":
+      return "준비중";
+    case "ARCHIVED":
+      return "종료됨";
+    default:
+      return status;
+  }
+};
+
+interface ConfirmDialogState {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  variant: "default" | "destructive";
+  onConfirm: () => Promise<void> | void;
+}
+
+const EMPTY_CONFIRM: ConfirmDialogState = {
+  open: false,
+  title: "",
+  description: "",
+  confirmLabel: "확인",
+  variant: "default",
+  onConfirm: () => {},
+};
+
+export function SeasonManagement() {
+  const isMobile = useIsMobile();
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [activeSeason, setActiveSeason] = useState<Season | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<Message | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [formName, setFormName] = useState("");
+  const [formStartDate, setFormStartDate] = useState("");
+  const [formEndDate, setFormEndDate] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const [confirm, setConfirm] = useState<ConfirmDialogState>(EMPTY_CONFIRM);
+
+  const fetchAll = async () => {
+    try {
+      setLoading(true);
+      const [list, active] = await Promise.all([
+        listSeasons(),
+        getActiveSeason(),
+      ]);
+      const sorted = [...list].sort((a, b) => b.id - a.id);
+      setSeasons(sorted);
+      setActiveSeason(active);
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text:
+          error instanceof Error
+            ? error.message
+            : "시즌 정보를 불러오지 못했습니다.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchAll();
+  }, []);
+
+  const openCreate = () => {
+    setFormName("");
+    setFormStartDate("");
+    setFormEndDate("");
+    setFormError(null);
+    setCreateOpen(true);
+  };
+
+  const closeCreate = () => {
+    if (creating) return;
+    setCreateOpen(false);
+    setFormError(null);
+  };
+
+  const handleCreate = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const trimmedName = formName.trim();
+    if (!trimmedName) {
+      setFormError("시즌 이름을 입력해 주세요.");
+      return;
+    }
+    if (!formStartDate || !formEndDate) {
+      setFormError("시작일과 종료일을 모두 입력해 주세요.");
+      return;
+    }
+    if (formStartDate >= formEndDate) {
+      setFormError("시작일은 종료일보다 빨라야 합니다.");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      await createSeason({
+        name: trimmedName,
+        startDate: formStartDate,
+        endDate: formEndDate,
+      });
+      setCreateOpen(false);
+      setMessage({
+        type: "success",
+        text: `'${trimmedName}' 시즌이 DRAFT 상태로 생성되었습니다.`,
+      });
+      await fetchAll();
+    } catch (error) {
+      setFormError(
+        error instanceof Error
+          ? error.message
+          : "시즌 생성 중 오류가 발생했습니다."
+      );
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleActivate = (season: Season) => {
+    setMessage(null);
+    setConfirm({
+      open: true,
+      title: "시즌 시작",
+      description: `'${season.name}' 시즌을 시작하시겠습니까?\n시작과 동시에 전체 유저에게 시즌 초기 코인이 지급되며,\n이전 시즌에 정산되지 않은 마켓이 있으면 활성화가 거부됩니다.`,
+      confirmLabel: "시즌 시작",
+      variant: "default",
+      onConfirm: async () => {
+        setActionLoading(true);
+        try {
+          const result = await activateSeason(season.id);
+          setMessage({
+            type: "success",
+            text: `'${season.name}' 시즌이 활성화되었습니다. ${result.usersGranted}명에게 초기 코인을 지급했습니다.`,
+          });
+          setConfirm(EMPTY_CONFIRM);
+          await fetchAll();
+        } catch (error) {
+          setMessage({
+            type: "error",
+            text:
+              error instanceof Error
+                ? error.message
+                : "시즌 활성화 중 오류가 발생했습니다.",
+          });
+          setConfirm(EMPTY_CONFIRM);
+        } finally {
+          setActionLoading(false);
+        }
+      },
+    });
+  };
+
+  const handleEnd = (season: Season) => {
+    setMessage(null);
+    setConfirm({
+      open: true,
+      title: "시즌 종료",
+      description: `'${season.name}' 시즌을 종료(ARCHIVED) 처리하시겠습니까?\n종료 후에는 다시 활성화할 수 없습니다.`,
+      confirmLabel: "시즌 종료",
+      variant: "destructive",
+      onConfirm: async () => {
+        setActionLoading(true);
+        try {
+          await endSeason(season.id);
+          setMessage({
+            type: "success",
+            text: `'${season.name}' 시즌이 종료되었습니다.`,
+          });
+          setConfirm(EMPTY_CONFIRM);
+          await fetchAll();
+        } catch (error) {
+          setMessage({
+            type: "error",
+            text:
+              error instanceof Error
+                ? error.message
+                : "시즌 종료 중 오류가 발생했습니다.",
+          });
+          setConfirm(EMPTY_CONFIRM);
+        } finally {
+          setActionLoading(false);
+        }
+      },
+    });
+  };
+
+  const closeConfirm = () => {
+    if (actionLoading) return;
+    setConfirm(EMPTY_CONFIRM);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="mb-2">
+        <h2
+          className={`font-bold text-black ${
+            isMobile ? "text-xl" : "text-2xl"
+          }`}
+        >
+          시즌 관리
+        </h2>
+        <p className="text-muted-foreground mt-2">
+          시즌을 생성하고 활성화/종료합니다. 활성 시즌이 바뀌면 전체 유저에게
+          초기 코인이 지급됩니다.
+        </p>
+      </div>
+
+      {message ? (
+        <div
+          className={`rounded-lg p-3 text-sm whitespace-pre-line ${
+            message.type === "success"
+              ? "bg-green-50 text-green-700"
+              : "bg-red-50 text-red-600"
+          }`}
+        >
+          {message.text}
+        </div>
+      ) : null}
+
+      <Card
+        className={`rounded-2xl border-tokhin-green/30 bg-tokhin-green/10 ${
+          isMobile ? "p-4" : "p-6"
+        }`}
+      >
+        {loading ? (
+          <p className="text-sm text-muted-foreground">
+            현재 활성 시즌을 불러오는 중...
+          </p>
+        ) : activeSeason ? (
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="flex items-center gap-3">
+              <span className="relative flex h-3 w-3">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-tokhin-green opacity-60" />
+                <span className="relative inline-flex h-3 w-3 rounded-full bg-tokhin-green" />
+              </span>
+              <div>
+                <div className="text-xs font-light text-tokhin-green">
+                  현재 진행중인 시즌
+                </div>
+                <div className="text-lg font-bold text-black">
+                  {activeSeason.name}
+                </div>
+                <div className="text-sm font-normal text-muted-foreground">
+                  {formatPeriod(activeSeason.startDate, activeSeason.endDate)}
+                </div>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-12 rounded-lg border-red-300 text-red-600 hover:bg-red-50"
+              onClick={() => handleEnd(activeSeason)}
+            >
+              시즌 종료
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-3 w-3 rounded-full bg-gray-300" />
+            <div className="text-sm font-normal text-muted-foreground">
+              현재 활성화된 시즌이 없습니다. 아래에서 새 시즌을 생성하거나
+              DRAFT 시즌을 시작해 주세요.
+            </div>
+          </div>
+        )}
+      </Card>
+
+      <div className={isMobile ? "" : "flex justify-end"}>
+        <Button
+          type="button"
+          onClick={openCreate}
+          className={`h-12 rounded-lg bg-tokhin-green text-white hover:bg-tokhin-green/90 ${
+            isMobile ? "w-full" : ""
+          }`}
+        >
+          + 새 시즌 생성
+        </Button>
+      </div>
+
+      {loading ? (
+        <Card className={`rounded-2xl ${isMobile ? "p-4" : "p-6"}`}>
+          <p className="text-sm text-muted-foreground">
+            시즌 목록을 불러오는 중...
+          </p>
+        </Card>
+      ) : seasons.length === 0 ? (
+        <Card className={`rounded-2xl ${isMobile ? "p-4" : "p-6"}`}>
+          <p className="text-sm text-muted-foreground">
+            등록된 시즌이 없습니다.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {seasons.map((season) => {
+            const isActive = season.status === "ACTIVE";
+            const isDraft = season.status === "DRAFT";
+            const isArchived = season.status === "ARCHIVED";
+            return (
+              <Card
+                key={season.id}
+                className={`rounded-2xl ${isMobile ? "p-4" : "p-5"} ${
+                  isArchived ? "opacity-60" : ""
+                }`}
+              >
+                <div
+                  className={`${
+                    isMobile
+                      ? "space-y-3"
+                      : "flex items-center justify-between gap-3"
+                  }`}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span
+                        className={`text-base font-bold ${
+                          isArchived ? "text-gray-500" : "text-black"
+                        }`}
+                      >
+                        {season.name}
+                      </span>
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusBadgeClass(
+                          season.status
+                        )}`}
+                      >
+                        {statusLabel(season.status)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm font-normal text-muted-foreground">
+                      {formatPeriod(season.startDate, season.endDate)}
+                    </p>
+                  </div>
+
+                  <div
+                    className={`${
+                      isMobile ? "flex justify-end gap-2" : "flex gap-2"
+                    }`}
+                  >
+                    {isDraft ? (
+                      <Button
+                        type="button"
+                        onClick={() => handleActivate(season)}
+                        className="h-12 rounded-lg bg-tokhin-green text-white hover:bg-tokhin-green/90"
+                      >
+                        시즌 시작
+                      </Button>
+                    ) : null}
+                    {isActive ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleEnd(season)}
+                        className="h-12 rounded-lg border-red-300 text-red-600 hover:bg-red-50"
+                      >
+                        시즌 종료
+                      </Button>
+                    ) : null}
+                    {isArchived ? (
+                      <span className="text-xs font-light text-muted-foreground self-center">
+                        종료된 시즌
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {createOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={closeCreate}
+        >
+          <Card
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h3 className="text-lg font-bold text-black">새 시즌 생성</h3>
+            <p className="mt-1 text-sm font-light text-muted-foreground">
+              DRAFT 상태로 생성됩니다. 생성 후 &quot;시즌 시작&quot; 버튼을
+              눌러 활성화할 수 있습니다.
+            </p>
+
+            <form onSubmit={handleCreate} className="mt-5 space-y-4">
+              <div>
+                <Label htmlFor="season-name" className="mb-2 block">
+                  시즌 이름
+                </Label>
+                <Input
+                  id="season-name"
+                  placeholder="예: Season 3"
+                  value={formName}
+                  onChange={(event) => setFormName(event.target.value)}
+                  disabled={creating}
+                  className="text-black"
+                />
+              </div>
+              <div>
+                <Label htmlFor="season-start" className="mb-2 block">
+                  시작일
+                </Label>
+                <Input
+                  id="season-start"
+                  type="date"
+                  value={formStartDate}
+                  onChange={(event) => setFormStartDate(event.target.value)}
+                  disabled={creating}
+                  className="text-black"
+                />
+              </div>
+              <div>
+                <Label htmlFor="season-end" className="mb-2 block">
+                  종료일
+                </Label>
+                <Input
+                  id="season-end"
+                  type="date"
+                  value={formEndDate}
+                  onChange={(event) => setFormEndDate(event.target.value)}
+                  disabled={creating}
+                  className="text-black"
+                />
+              </div>
+
+              {formError ? (
+                <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
+                  {formError}
+                </div>
+              ) : null}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={closeCreate}
+                  disabled={creating}
+                  className="h-12 rounded-lg"
+                >
+                  취소
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={creating}
+                  className="h-12 rounded-lg bg-tokhin-green text-white hover:bg-tokhin-green/90"
+                >
+                  {creating ? "생성 중..." : "생성"}
+                </Button>
+              </div>
+            </form>
+          </Card>
+        </div>
+      ) : null}
+
+      {confirm.open ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={closeConfirm}
+        >
+          <Card
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h3 className="text-lg font-bold text-black">{confirm.title}</h3>
+            <p className="mt-3 text-sm font-normal whitespace-pre-line text-muted-foreground">
+              {confirm.description}
+            </p>
+
+            <div className="mt-6 flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeConfirm}
+                disabled={actionLoading}
+                className="h-12 rounded-lg"
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void confirm.onConfirm()}
+                disabled={actionLoading}
+                className={`h-12 rounded-lg text-white ${
+                  confirm.variant === "destructive"
+                    ? "bg-red-600 hover:bg-red-700"
+                    : "bg-tokhin-green hover:bg-tokhin-green/90"
+                }`}
+              >
+                {actionLoading ? "처리 중..." : confirm.confirmLabel}
+              </Button>
+            </div>
+          </Card>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -30,6 +30,7 @@ import {
   type MarketListItem,
   type MarketOutcome,
 } from "@/lib/api";
+import { SeasonManagement } from "./SeasonManagement";
 
 // Interface definitions
 interface Team {
@@ -2021,6 +2022,7 @@ function AdminDashboard() {
   const isMobile = useIsMobile();
   const [currentView, setCurrentView] = useState<
     | "dashboard"
+    | "seasons"
     | "matches"
     | "coins"
     | "markets"
@@ -2052,7 +2054,9 @@ function AdminDashboard() {
           </div>
         </div>
 
-        {currentView === "coins" ? (
+        {currentView === "seasons" ? (
+          <SeasonManagement />
+        ) : currentView === "coins" ? (
           <CoinGrantManagement />
         ) : currentView === "password" ? (
           <PasswordResetManagement />
@@ -2114,6 +2118,23 @@ function AdminDashboard() {
             : "grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4"
         }`}
       >
+        <Card className={`rounded-2xl border-tokhin-green/30 bg-tokhin-green/5 ${isMobile ? "p-4" : "p-6"}`}>
+          <h3
+            className={`font-bold mb-3 text-black ${isMobile ? "text-lg" : "text-xl"}`}
+          >
+            시즌 관리
+          </h3>
+          <p className="text-muted-foreground mb-4">
+            시즌 생성, 활성화, 종료를 관리합니다.
+          </p>
+          <Button
+            onClick={() => setCurrentView("seasons")}
+            className={`bg-tokhin-green text-white hover:bg-tokhin-green/90 ${isMobile ? "w-full" : ""}`}
+          >
+            접속
+          </Button>
+        </Card>
+
         <Card className={isMobile ? "p-4" : "p-6"}>
           <h3
             className={`font-semibold mb-3 ${isMobile ? "text-lg" : "text-xl"}`}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  getActiveSeason,
   getOrderHistory,
   getPositions,
   getSettlementHistory,
+  listSeasons,
   type OpenPositionHistoryItem,
   type OrderHistoryItem,
+  type Season,
   type SettlementHistoryItem,
 } from "@/lib/api";
 import { useUserSession } from "@/lib/hooks/useUserSession";
@@ -205,6 +208,33 @@ const formatPositionsSummary = (
   return summaryItems.length > 0 ? summaryItems.join(" · ") : "보유 포지션 없음";
 };
 
+const formatSeasonOptionLabel = (season: Season) => {
+  const statusLabel =
+    season.status === "ACTIVE"
+      ? "활성"
+      : season.status === "ARCHIVED"
+      ? "보관"
+      : "준비 중";
+  return `${season.name} (${statusLabel})`;
+};
+
+type SeasonBadgeProps = {
+  seasonName: string;
+  isActiveSeason: boolean;
+};
+
+const SeasonBadge = ({ seasonName, isActiveSeason }: SeasonBadgeProps) => {
+  if (!seasonName) {
+    return null;
+  }
+
+  const className = isActiveSeason
+    ? "rounded-md bg-tokhin-green/10 px-2 py-0.5 text-xs font-medium text-tokhin-green"
+    : "rounded-md bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-700";
+
+  return <span className={className}>{seasonName}</span>;
+};
+
 export default function HistoryPage() {
   const { session, isLoading: isSessionLoading } = useUserSession({
     requireAuth: true,
@@ -231,6 +261,12 @@ export default function HistoryPage() {
   const [positionsError, setPositionsError] = useState<string | null>(null);
   const [ordersError, setOrdersError] = useState<string | null>(null);
   const [settlementsError, setSettlementsError] = useState<string | null>(null);
+
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [activeSeason, setActiveSeason] = useState<Season | null>(null);
+  const [selectedSeasonId, setSelectedSeasonId] = useState<number | undefined>(
+    undefined
+  );
 
   const calendarRef = useRef<HTMLDivElement>(null);
 
@@ -261,6 +297,35 @@ export default function HistoryPage() {
   }, [showCalendar]);
 
   useEffect(() => {
+    let isCancelled = false;
+
+    const fetchSeasonsMeta = async () => {
+      try {
+        const [seasonList, active] = await Promise.all([
+          listSeasons(),
+          getActiveSeason(),
+        ]);
+
+        if (!isCancelled) {
+          setSeasons(seasonList);
+          setActiveSeason(active);
+        }
+      } catch {
+        if (!isCancelled) {
+          setSeasons([]);
+          setActiveSeason(null);
+        }
+      }
+    };
+
+    void fetchSeasonsMeta();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!session?.user_id) {
       return;
     }
@@ -272,7 +337,7 @@ export default function HistoryPage() {
       setPositionsError(null);
 
       try {
-        const data = await getPositions(session.user_id);
+        const data = await getPositions(session.user_id, activeSeason?.id);
 
         if (!isCancelled) {
           setOpenPositions(data);
@@ -297,7 +362,7 @@ export default function HistoryPage() {
     return () => {
       isCancelled = true;
     };
-  }, [session?.user_id]);
+  }, [session?.user_id, activeSeason?.id]);
 
   useEffect(() => {
     if (!session?.user_id) {
@@ -311,7 +376,11 @@ export default function HistoryPage() {
       setOrdersError(null);
 
       try {
-        const data = await getOrderHistory(session.user_id, selectedDate);
+        const data = await getOrderHistory(
+          session.user_id,
+          selectedDate,
+          selectedSeasonId
+        );
 
         if (!isCancelled) {
           setOrderHistory(data);
@@ -336,7 +405,7 @@ export default function HistoryPage() {
     return () => {
       isCancelled = true;
     };
-  }, [selectedDate, session?.user_id]);
+  }, [selectedDate, session?.user_id, selectedSeasonId]);
 
   useEffect(() => {
     if (!session?.user_id) {
@@ -350,7 +419,10 @@ export default function HistoryPage() {
       setSettlementsError(null);
 
       try {
-        const data = await getSettlementHistory(session.user_id);
+        const data = await getSettlementHistory(
+          session.user_id,
+          selectedSeasonId
+        );
 
         if (!isCancelled) {
           setSettlementHistory(data);
@@ -375,7 +447,7 @@ export default function HistoryPage() {
     return () => {
       isCancelled = true;
     };
-  }, [session?.user_id]);
+  }, [session?.user_id, selectedSeasonId]);
 
   const groupedOrderHistory = useMemo(() => {
     const groups = new Map<string, OrderHistoryItem[]>();
@@ -470,6 +542,29 @@ export default function HistoryPage() {
         </div>
       </div>
 
+      {(activeTab === "ORDERS" || activeTab === "SETTLEMENTS") && (
+        <div className="mb-4 flex items-center justify-end">
+          <label className="flex items-center gap-2 text-xs text-stone-500">
+            <span>시즌</span>
+            <select
+              value={selectedSeasonId ?? ""}
+              onChange={(event) => {
+                const value = event.target.value;
+                setSelectedSeasonId(value === "" ? undefined : Number(value));
+              }}
+              className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors focus:border-tokhin-green focus:outline-none"
+            >
+              <option value="">전체</option>
+              {seasons.map((season) => (
+                <option key={season.id} value={season.id}>
+                  {formatSeasonOptionLabel(season)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      )}
+
       {activeTab === "ORDERS" && (
         <div className="mb-5 mt-1 flex flex-col items-center">
           <div className="relative mb-1 flex items-center justify-center gap-1">
@@ -559,6 +654,10 @@ export default function HistoryPage() {
 
       {activeTab === "OPEN_POSITIONS" && (
         <div className="space-y-3">
+          <p className="text-xs text-stone-500">
+            현재 활성 시즌의 포지션만 표시됩니다
+            {activeSeason ? ` · ${activeSeason.name}` : ""}
+          </p>
           {isPositionsLoading ? (
             <p className="py-12 text-center text-zinc-500">포지션을 불러오는 중...</p>
           ) : positionsError ? (
@@ -593,9 +692,15 @@ export default function HistoryPage() {
                         {homeTeamName}
                       </span>
                     </p>
-                    <p className="text-xs text-zinc-500">
-                      {formatGameDate(position.gameDate)} {formatGameTime(position.gameTime)}
-                    </p>
+                    <div className="flex items-center gap-2">
+                      <SeasonBadge
+                        seasonName={position.seasonName}
+                        isActiveSeason={position.seasonId === activeSeason?.id}
+                      />
+                      <p className="text-xs text-zinc-500">
+                        {formatGameDate(position.gameDate)} {formatGameTime(position.gameTime)}
+                      </p>
+                    </div>
                   </div>
 
                   <p className="text-sm font-semibold text-zinc-700">
@@ -654,10 +759,16 @@ export default function HistoryPage() {
                         key={order.orderId}
                         className="rounded-2xl bg-white p-5 shadow-[0px_2px_12px_0px_rgba(0,0,0,0.12)]"
                       >
-                        <div className="mb-2 flex items-center justify-between">
-                          <p className="text-xs text-zinc-500">
-                            {formatKstDateTime(order.createdAt)}
-                          </p>
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
+                            <p className="text-xs text-zinc-500">
+                              {formatKstDateTime(order.createdAt)}
+                            </p>
+                            <SeasonBadge
+                              seasonName={order.seasonName}
+                              isActiveSeason={order.seasonId === activeSeason?.id}
+                            />
+                          </div>
                           <span
                             className={`rounded-full px-2.5 py-1 text-xs font-semibold ${sideClass}`}
                           >
@@ -725,9 +836,15 @@ export default function HistoryPage() {
                         {homeTeamName}
                       </span>
                     </p>
-                    <p className="text-xs text-zinc-500">
-                      {formatKstDateTime(settlement.settledAt)}
-                    </p>
+                    <div className="flex items-center gap-2">
+                      <SeasonBadge
+                        seasonName={settlement.seasonName}
+                        isActiveSeason={settlement.seasonId === activeSeason?.id}
+                      />
+                      <p className="text-xs text-zinc-500">
+                        {formatKstDateTime(settlement.settledAt)}
+                      </p>
+                    </div>
                   </div>
 
                   <p className="text-sm text-zinc-700">

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -2,12 +2,16 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
+  getActiveSeason,
   getLeaderboardBalance,
   getLeaderboardRoi,
+  listSeasons,
   type LeaderboardBalanceItem,
   type LeaderboardRoiItem,
+  type Season,
 } from "@/lib/api";
 import { useUserSession } from "@/lib/hooks/useUserSession";
+import { Select } from "@/components/ui/select";
 
 type LeaderboardTab = "BALANCE" | "ROI";
 
@@ -48,6 +52,16 @@ const getRankBackgroundClass = (rank: number) => {
   return rank === 1 ? "bg-tokhin-green" : "bg-neutral-50";
 };
 
+const getSeasonLabel = (season: Season) => {
+  const suffix =
+    season.status === "ACTIVE"
+      ? "활성"
+      : season.status === "ARCHIVED"
+        ? "보관"
+        : "준비";
+  return `${season.name} (${suffix})`;
+};
+
 export default function LeaderboardPage() {
   const { session, isLoading: isSessionLoading } = useUserSession({
     requireAuth: true,
@@ -58,11 +72,63 @@ export default function LeaderboardPage() {
     LeaderboardBalanceItem[]
   >([]);
   const [roiLeaderboard, setRoiLeaderboard] = useState<LeaderboardRoiItem[]>([]);
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [selectedSeasonId, setSelectedSeasonId] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!session?.user_id) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    const fetchSeasons = async () => {
+      try {
+        const [allSeasons, activeSeason] = await Promise.all([
+          listSeasons(),
+          getActiveSeason(),
+        ]);
+
+        if (isCancelled) {
+          return;
+        }
+
+        const selectable = allSeasons.filter((s) => s.status !== "DRAFT");
+        setSeasons(selectable);
+
+        const defaultId =
+          activeSeason?.id ?? selectable[0]?.id ?? null;
+        setSelectedSeasonId(defaultId);
+
+        if (defaultId === null) {
+          setIsLoading(false);
+        }
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : "시즌 목록을 불러오지 못했습니다";
+
+        setErrorMessage(message);
+        setIsLoading(false);
+      }
+    };
+
+    fetchSeasons();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [session?.user_id]);
+
+  useEffect(() => {
+    if (!session?.user_id || selectedSeasonId === null) {
       return;
     }
 
@@ -73,8 +139,8 @@ export default function LeaderboardPage() {
 
       try {
         const [balanceData, roiData] = await Promise.all([
-          getLeaderboardBalance(),
-          getLeaderboardRoi(),
+          getLeaderboardBalance(selectedSeasonId),
+          getLeaderboardRoi(selectedSeasonId),
         ]);
 
         if (isCancelled) {
@@ -108,7 +174,7 @@ export default function LeaderboardPage() {
     return () => {
       isCancelled = true;
     };
-  }, [session?.user_id]);
+  }, [session?.user_id, selectedSeasonId]);
 
   const displayRows = useMemo<LeaderboardDisplayRow[]>(() => {
     if (activeTab === "BALANCE") {
@@ -140,6 +206,35 @@ export default function LeaderboardPage() {
     <div className="w-full pt-1">
       <h1 className="mb-6 text-center text-xl font-bold text-black">리더보드</h1>
 
+      <div className="mb-4 flex items-center gap-3 rounded-lg bg-neutral-50 px-3 py-2 shadow-[0px_0px_8px_0px_rgba(0,0,0,0.06)]">
+        <label
+          htmlFor="season-select"
+          className="text-sm font-semibold text-zinc-700"
+        >
+          시즌
+        </label>
+        <Select
+          id="season-select"
+          value={selectedSeasonId ?? ""}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            setSelectedSeasonId(nextValue === "" ? null : Number(nextValue));
+          }}
+          disabled={seasons.length === 0}
+          className="h-10 flex-1 rounded-lg border-zinc-200 bg-white text-sm font-medium text-black"
+        >
+          {seasons.length === 0 ? (
+            <option value="">선택 가능한 시즌이 없습니다</option>
+          ) : (
+            seasons.map((season) => (
+              <option key={season.id} value={season.id}>
+                {getSeasonLabel(season)}
+              </option>
+            ))
+          )}
+        </Select>
+      </div>
+
       <div className="mb-5 border-b border-zinc-200">
         <div className="grid grid-cols-2">
           {LEADERBOARD_TABS.map((tab) => (
@@ -164,9 +259,8 @@ export default function LeaderboardPage() {
       ) : errorMessage ? (
         <p className="text-center text-red-500">{errorMessage}</p>
       ) : displayRows.length === 0 ? (
-        <p className="text-center text-gray-600">
-          아직 {activeTab === "BALANCE" ? "잔고" : "수익률"} 순위표를 볼 수
-          없습니다.
+        <p className="py-10 text-center text-gray-600">
+          이 시즌에 거래 기록이 없습니다
         </p>
       ) : (
         <div>

--- a/app/market/[id]/page.tsx
+++ b/app/market/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   executeBuyByAmount,
   executeBuyOrder,
   executeSellOrder,
+  getActiveSeason,
   getMarketDetail,
   getMarketPositions,
   getPriceSnapshots,
@@ -19,6 +20,7 @@ import {
   type MarketOutcome,
   type MarketPositionsByOutcome,
   type PriceSnapshotItem,
+  type Season,
 } from "@/lib/api";
 import { notifyWalletBalanceRefresh } from "@/lib/events";
 import { useUserSession } from "@/lib/hooks/useUserSession";
@@ -475,6 +477,7 @@ export default function MarketDetailPage() {
     createEmptyPositionsByOutcome
   );
   const [walletBalance, setWalletBalance] = useState(0);
+  const [activeSeason, setActiveSeason] = useState<Season | null>(null);
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -502,17 +505,20 @@ export default function MarketDetailPage() {
     setError(null);
 
     try {
-      const [detail, userPositions, balance, snapshots] = await Promise.all([
-        getMarketDetail(marketId),
-        getMarketPositions(session.user_id, marketId),
-        getWalletBalance(session.user_id),
-        getPriceSnapshots(marketId),
-      ]);
+      const [detail, userPositions, balance, snapshots, season] =
+        await Promise.all([
+          getMarketDetail(marketId),
+          getMarketPositions(session.user_id, marketId),
+          getWalletBalance(session.user_id),
+          getPriceSnapshots(marketId),
+          getActiveSeason(),
+        ]);
 
       setMarketDetail(detail);
       setPositions(userPositions);
       setWalletBalance(balance);
       setPriceSnapshots(snapshots);
+      setActiveSeason(season);
     } catch (loadError) {
       console.error("Failed to load market detail page data:", loadError);
       setError("마켓 정보를 불러오는 중 오류가 발생했습니다");
@@ -633,9 +639,18 @@ export default function MarketDetailPage() {
     );
   }, [currentTime, marketDetail]);
 
+  const isArchivedSeasonMarket = useMemo<boolean>(() => {
+    if (!marketDetail) {
+      return false;
+    }
+
+    return marketDetail.seasonId !== (activeSeason?.id ?? null);
+  }, [activeSeason, marketDetail]);
+
   const isTradingClosed =
     closedHours ||
     isTradeDeadlinePassed ||
+    isArchivedSeasonMarket ||
     displayStatus === "CLOSED" ||
     displayStatus === "SETTLED" ||
     displayStatus === "CANCELED";
@@ -873,6 +888,15 @@ export default function MarketDetailPage() {
       return;
     }
 
+    if (isArchivedSeasonMarket) {
+      setIsConfirmOpen(false);
+      setToast({
+        type: "error",
+        message: "보관된 시즌의 마켓은 거래할 수 없습니다",
+      });
+      return;
+    }
+
     if (isTradingClosed) {
       setIsConfirmOpen(false);
       setToast({
@@ -989,11 +1013,24 @@ export default function MarketDetailPage() {
           <Link href="/" className="text-sm font-semibold text-zinc-600">
             ← 마켓 목록
           </Link>
-          <span
-            className={`rounded-full px-3 py-1 text-xs font-semibold ${STATUS_BADGE_CLASSES[displayStatus]}`}
-          >
-            {displayStatus}
-          </span>
+          <div className="flex items-center gap-2">
+            {marketDetail.seasonName ? (
+              <span
+                className={`rounded-md px-2 py-0.5 text-xs font-semibold ${
+                  isArchivedSeasonMarket
+                    ? "bg-stone-100 text-stone-700"
+                    : "bg-tokhin-green/10 text-tokhin-green"
+                }`}
+              >
+                {marketDetail.seasonName}
+              </span>
+            ) : null}
+            <span
+              className={`rounded-full px-3 py-1 text-xs font-semibold ${STATUS_BADGE_CLASSES[displayStatus]}`}
+            >
+              {displayStatus}
+            </span>
+          </div>
         </div>
 
         {error ? <p className="text-sm text-red-500">{error}</p> : null}
@@ -1152,6 +1189,16 @@ export default function MarketDetailPage() {
           )}
         </section>
 
+        {isArchivedSeasonMarket ? (
+          <section className="rounded-2xl border border-stone-200 bg-stone-100 p-4 text-center">
+            <p className="text-sm font-semibold text-stone-700">
+              보관된 시즌의 마켓입니다
+            </p>
+            <p className="mt-1 text-sm text-stone-500">
+              {marketDetail.seasonName ?? "지난 시즌"}의 거래는 종료되었습니다
+            </p>
+          </section>
+        ) : (
         <section
           className={`rounded-2xl border p-5 shadow-[0px_2px_12px_0px_rgba(0,0,0,0.12)] ${
             tradeSide === "BUY"
@@ -1356,6 +1403,7 @@ export default function MarketDetailPage() {
             {tradeSide === "BUY" ? "매수 주문하기" : "매도 주문하기"}
           </Button>
         </section>
+        )}
       </div>
 
       {isConfirmOpen && tradePreview ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,13 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import {
+  getActiveSeason,
   getISODate,
   getMarkets,
   isMarketClosedHours,
   isMarketPastTradeDeadline,
   type MarketListItem,
+  type Season,
 } from "@/lib/api";
 import { useUserSession } from "@/lib/hooks/useUserSession";
 
@@ -154,6 +156,7 @@ export default function HomePage() {
     requireAuth: true,
   });
   const [markets, setMarkets] = useState<MarketListItem[]>([]);
+  const [activeSeason, setActiveSeason] = useState<Season | null>(null);
   const [displayDate, setDisplayDate] = useState<string>(getISODate());
   const [displayDateLabel, setDisplayDateLabel] =
     useState<MarketDateLabel>("today");
@@ -171,8 +174,21 @@ export default function HomePage() {
     setError(null);
 
     try {
+      const season = await getActiveSeason();
+      setActiveSeason(season);
+
+      if (!season) {
+        setMarkets([]);
+        setDisplayDate(getISODate());
+        setDisplayDateLabel("today");
+        return;
+      }
+
+      const filterBySeason = (list: MarketListItem[]) =>
+        list.filter((market) => market.seasonId === season.id);
+
       const today = getISODate();
-      const todayMarkets = await getMarkets(today);
+      const todayMarkets = filterBySeason(await getMarkets(today));
 
       const allTodayGamesEnded =
         todayMarkets.length > 0 &&
@@ -182,7 +198,7 @@ export default function HomePage() {
         const tomorrow = new Date();
         tomorrow.setDate(tomorrow.getDate() + 1);
         const tomorrowDate = getISODate(tomorrow);
-        const tomorrowMarkets = await getMarkets(tomorrowDate);
+        const tomorrowMarkets = filterBySeason(await getMarkets(tomorrowDate));
 
         if (tomorrowMarkets.length > 0) {
           setMarkets(tomorrowMarkets);
@@ -245,14 +261,25 @@ export default function HomePage() {
         </div>
       ) : null}
 
-      <h1 className="mb-4 text-lg font-bold text-black">
-        {formatMarketDateTitle(displayDate, displayDateLabel)}
-      </h1>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h1 className="text-lg font-bold text-black">
+          {formatMarketDateTitle(displayDate, displayDateLabel)}
+        </h1>
+        {activeSeason ? (
+          <span className="shrink-0 rounded-full bg-tokhin-green/10 px-2.5 py-0.5 text-xs font-semibold text-tokhin-green">
+            {activeSeason.name} 활성
+          </span>
+        ) : null}
+      </div>
 
       {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
 
       {isLoading ? (
         <p className="py-20 text-center text-zinc-500">마켓 목록을 불러오는 중...</p>
+      ) : !activeSeason ? (
+        <div className="rounded-2xl bg-white p-5 text-center shadow-[0px_2px_12px_0px_rgba(0,0,0,0.12)]">
+          <p className="text-sm text-zinc-500">현재 활성 시즌이 없습니다</p>
+        </div>
       ) : markets.length === 0 ? (
         <div className="rounded-2xl bg-white p-5 text-center shadow-[0px_2px_12px_0px_rgba(0,0,0,0.12)]">
           <p className="text-sm text-zinc-500">표시할 마켓이 없습니다.</p>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -26,6 +26,7 @@ interface LoginRpcResponse {
 interface WalletBalanceRpcResponse {
   success: boolean;
   balance?: number | string;
+  season_id?: number | string | null;
   error?: string;
 }
 
@@ -128,6 +129,7 @@ interface MarketForListRow {
   game_id: number;
   status: string;
   result: string | null;
+  season_id: number | null;
   initial_home_price: number | string | null;
   initial_away_price: number | string | null;
   initial_draw_price: number | string | null;
@@ -151,6 +153,8 @@ interface MarketDetailRpcPayload {
     initial_home_price: number | string | null;
     initial_away_price: number | string | null;
     initial_draw_price: number | string | null;
+    season_id?: number | string | null;
+    season_name?: string | null;
   };
   prices?: LmsrPriceRow[] | null;
   game?: {
@@ -190,6 +194,8 @@ interface UserOpenPositionRpcRow {
   outcome: string;
   quantity: number | string;
   avg_entry_price: number | string;
+  season_id: number | string;
+  season_name: string;
   updated_at: string;
 }
 
@@ -201,6 +207,8 @@ interface UserOrderByDateRpcRow {
   quantity: number | string;
   total_cost: number | string;
   avg_price: number | string;
+  season_id: number | string;
+  season_name: string;
   created_at: string;
 }
 
@@ -213,6 +221,8 @@ interface UserSettlementHistoryRpcRow {
   home_quantity: number | string;
   away_quantity: number | string;
   draw_quantity: number | string;
+  season_id: number | string;
+  season_name: string;
 }
 
 interface MarketForHistoryContextRow {
@@ -246,6 +256,61 @@ interface LeaderboardRoiRpcRow {
   total_granted: number | string;
 }
 
+interface LeaderboardBalanceRpcResponse {
+  success: boolean;
+  season_id?: number | string | null;
+  ranks?: LeaderboardBalanceRpcRow[];
+  error?: string;
+}
+
+interface LeaderboardRoiRpcResponse {
+  success: boolean;
+  season_id?: number | string | null;
+  ranks?: LeaderboardRoiRpcRow[];
+  error?: string;
+}
+
+interface SeasonRpcShape {
+  id: number | string;
+  name: string;
+  start_date: string | null;
+  end_date: string | null;
+  status: "DRAFT" | "ACTIVE" | "ARCHIVED";
+  created_at?: string;
+}
+
+interface GetActiveSeasonRpcResponse {
+  success: boolean;
+  season?: SeasonRpcShape | null;
+  error?: string;
+}
+
+interface ListSeasonsRpcResponse {
+  success: boolean;
+  seasons?: SeasonRpcShape[];
+  error?: string;
+}
+
+interface CreateSeasonRpcResponse {
+  success: boolean;
+  season?: SeasonRpcShape;
+  error?: string;
+}
+
+interface ActivateSeasonRpcResponse {
+  success: boolean;
+  season_id?: number | string;
+  users_granted?: number | string;
+  error?: string;
+}
+
+interface EndSeasonRpcResponse {
+  success: boolean;
+  season_id?: number | string;
+  status?: "ARCHIVED";
+  error?: string;
+}
+
 export interface MarketListItem {
   id: number;
   gameId: number;
@@ -260,6 +325,7 @@ export interface MarketListItem {
   awayTeamShortName: string | null;
   homeScore: number | null;
   awayScore: number | null;
+  seasonId: number | null;
   prices: Record<MarketOutcome, number>;
   initialPrices: Record<MarketOutcome, number | null>;
 }
@@ -296,6 +362,8 @@ export interface MarketDetailItem {
   awayPitcher: string | null;
   homeScore: number | null;
   awayScore: number | null;
+  seasonId: number | null;
+  seasonName: string | null;
 }
 
 export interface MarketPosition {
@@ -329,6 +397,8 @@ export interface OpenPositionHistoryItem {
   awayTeamName: string;
   homeTeamShortName: string | null;
   awayTeamShortName: string | null;
+  seasonId: number;
+  seasonName: string;
 }
 
 export interface OrderHistoryItem {
@@ -346,6 +416,8 @@ export interface OrderHistoryItem {
   awayTeamName: string;
   homeTeamShortName: string | null;
   awayTeamShortName: string | null;
+  seasonId: number;
+  seasonName: string;
 }
 
 export interface SettlementHistoryItem {
@@ -362,6 +434,8 @@ export interface SettlementHistoryItem {
   awayTeamName: string;
   homeTeamShortName: string | null;
   awayTeamShortName: string | null;
+  seasonId: number;
+  seasonName: string;
 }
 
 export interface LeaderboardBalanceItem {
@@ -369,6 +443,7 @@ export interface LeaderboardBalanceItem {
   userId: string;
   username: string;
   balance: number;
+  seasonId?: number;
 }
 
 export interface LeaderboardRoiItem {
@@ -378,6 +453,34 @@ export interface LeaderboardRoiItem {
   roiPercent: number;
   currentBalance: number;
   totalGranted: number;
+  seasonId?: number;
+}
+
+export type SeasonStatus = "DRAFT" | "ACTIVE" | "ARCHIVED";
+
+export interface Season {
+  id: number;
+  name: string;
+  startDate: string | null;
+  endDate: string | null;
+  status: SeasonStatus;
+  createdAt?: string;
+}
+
+export interface SeasonInput {
+  name: string;
+  startDate: string;
+  endDate: string;
+}
+
+export interface SeasonActivationResult {
+  seasonId: number;
+  usersGranted: number;
+}
+
+export interface SeasonEndResult {
+  seasonId: number;
+  status: "ARCHIVED";
 }
 
 export interface PriceSnapshotItem {
@@ -705,35 +808,58 @@ export const changePassword = async (userId: string, newPassword: string) => {
 };
 
 // Fetch Leaderboard (US-008)
-export const getLeaderboardBalance = async (): Promise<
-  LeaderboardBalanceItem[]
-> => {
-  const { data, error } = await supabase.rpc("get_leaderboard_balance");
+export const getLeaderboardBalance = async (
+  seasonId?: number
+): Promise<LeaderboardBalanceItem[]> => {
+  const { data, error } = await supabase.rpc("get_leaderboard_balance", {
+    p_season_id: seasonId ?? null,
+  });
 
   if (error) {
     console.error("Error calling get_leaderboard_balance RPC:", error);
     throw new Error("리더보드 잔고 순위 조회 중 오류가 발생했습니다");
   }
 
-  const rows = (data ?? []) as LeaderboardBalanceRpcRow[];
+  const rpcResult = data as LeaderboardBalanceRpcResponse | null;
+  if (!rpcResult?.success) {
+    throw new Error(
+      rpcResult?.error || "리더보드 잔고 순위 조회에 실패했습니다"
+    );
+  }
+
+  const responseSeasonId = toNumberOrNull(rpcResult.season_id ?? null);
+  const rows = (rpcResult.ranks ?? []) as LeaderboardBalanceRpcRow[];
 
   return rows.map((entry) => ({
     rank: Math.trunc(toNumberOrNull(entry.rank) ?? 0),
     userId: entry.user_id,
     username: entry.username,
     balance: toNumberOrNull(entry.balance) ?? 0,
+    seasonId: responseSeasonId ?? undefined,
   }));
 };
 
-export const getLeaderboardRoi = async (): Promise<LeaderboardRoiItem[]> => {
-  const { data, error } = await supabase.rpc("get_leaderboard_roi");
+export const getLeaderboardRoi = async (
+  seasonId?: number
+): Promise<LeaderboardRoiItem[]> => {
+  const { data, error } = await supabase.rpc("get_leaderboard_roi", {
+    p_season_id: seasonId ?? null,
+  });
 
   if (error) {
     console.error("Error calling get_leaderboard_roi RPC:", error);
     throw new Error("리더보드 수익률 순위 조회 중 오류가 발생했습니다");
   }
 
-  const rows = (data ?? []) as LeaderboardRoiRpcRow[];
+  const rpcResult = data as LeaderboardRoiRpcResponse | null;
+  if (!rpcResult?.success) {
+    throw new Error(
+      rpcResult?.error || "리더보드 수익률 순위 조회에 실패했습니다"
+    );
+  }
+
+  const responseSeasonId = toNumberOrNull(rpcResult.season_id ?? null);
+  const rows = (rpcResult.ranks ?? []) as LeaderboardRoiRpcRow[];
 
   return rows.map((entry) => ({
     rank: Math.trunc(toNumberOrNull(entry.rank) ?? 0),
@@ -742,7 +868,152 @@ export const getLeaderboardRoi = async (): Promise<LeaderboardRoiItem[]> => {
     roiPercent: toNumberOrNull(entry.roi_percent) ?? 0,
     currentBalance: toNumberOrNull(entry.current_balance) ?? 0,
     totalGranted: toNumberOrNull(entry.total_granted) ?? 0,
+    seasonId: responseSeasonId ?? undefined,
   }));
+};
+
+// Season Management Functions (US-001, US-002)
+
+const parseSeasonFromRpc = (raw: SeasonRpcShape): Season => {
+  const parsedId = Number(raw.id);
+  if (!Number.isFinite(parsedId) || parsedId <= 0) {
+    throw new Error("시즌 데이터 형식이 올바르지 않습니다");
+  }
+
+  return {
+    id: parsedId,
+    name: raw.name,
+    startDate: raw.start_date ?? null,
+    endDate: raw.end_date ?? null,
+    status: raw.status,
+    createdAt: raw.created_at,
+  };
+};
+
+export const getActiveSeason = async (): Promise<Season | null> => {
+  const { data, error } = await supabase.rpc("get_active_season");
+
+  if (error) {
+    console.error("Error calling get_active_season RPC:", error);
+    throw new Error("활성 시즌 조회 중 오류가 발생했습니다");
+  }
+
+  const rpcResult = data as GetActiveSeasonRpcResponse | null;
+  if (!rpcResult?.success || !rpcResult.season) {
+    return null;
+  }
+
+  return parseSeasonFromRpc(rpcResult.season);
+};
+
+export const listSeasons = async (): Promise<Season[]> => {
+  const { data, error } = await supabase.rpc("list_seasons");
+
+  if (error) {
+    console.error("Error calling list_seasons RPC:", error);
+    throw new Error("시즌 목록 조회 중 오류가 발생했습니다");
+  }
+
+  const rpcResult = data as ListSeasonsRpcResponse | null;
+  if (!rpcResult?.success) {
+    throw new Error(rpcResult?.error || "시즌 목록 조회에 실패했습니다");
+  }
+
+  return (rpcResult.seasons ?? []).map(parseSeasonFromRpc);
+};
+
+export const createSeason = async (input: SeasonInput): Promise<Season> => {
+  if (!input.name || !input.name.trim()) {
+    throw new Error("시즌 이름이 비어 있습니다");
+  }
+
+  if (!input.startDate || !input.endDate) {
+    throw new Error("시즌 시작/종료 날짜가 비어 있습니다");
+  }
+
+  const { data, error } = await supabase.rpc("create_season", {
+    p_name: input.name,
+    p_start_date: input.startDate,
+    p_end_date: input.endDate,
+  });
+
+  if (error) {
+    console.error("Error calling create_season RPC:", error);
+    throw new Error("시즌 생성 중 오류가 발생했습니다");
+  }
+
+  const rpcResult = data as CreateSeasonRpcResponse | null;
+  if (!rpcResult?.success || !rpcResult.season) {
+    throw new Error(rpcResult?.error || "시즌 생성에 실패했습니다");
+  }
+
+  return parseSeasonFromRpc(rpcResult.season);
+};
+
+export const activateSeason = async (
+  seasonId: number
+): Promise<SeasonActivationResult> => {
+  if (!Number.isFinite(seasonId) || seasonId <= 0) {
+    throw new Error("유효하지 않은 시즌 ID입니다");
+  }
+
+  const { data, error } = await supabase.rpc("activate_season", {
+    p_season_id: seasonId,
+  });
+
+  if (error) {
+    console.error("Error calling activate_season RPC:", error);
+    throw new Error("시즌 활성화 중 오류가 발생했습니다");
+  }
+
+  const rpcResult = data as ActivateSeasonRpcResponse | null;
+  if (!rpcResult?.success) {
+    throw new Error(rpcResult?.error || "시즌 활성화에 실패했습니다");
+  }
+
+  const parsedSeasonId = Number(rpcResult.season_id ?? seasonId);
+  const usersGranted = Number(rpcResult.users_granted ?? 0);
+
+  if (!Number.isFinite(parsedSeasonId) || !Number.isFinite(usersGranted)) {
+    throw new Error("시즌 활성화 응답 형식이 올바르지 않습니다");
+  }
+
+  return {
+    seasonId: parsedSeasonId,
+    usersGranted,
+  };
+};
+
+export const endSeason = async (
+  seasonId: number
+): Promise<SeasonEndResult> => {
+  if (!Number.isFinite(seasonId) || seasonId <= 0) {
+    throw new Error("유효하지 않은 시즌 ID입니다");
+  }
+
+  const { data, error } = await supabase.rpc("end_season", {
+    p_season_id: seasonId,
+  });
+
+  if (error) {
+    console.error("Error calling end_season RPC:", error);
+    throw new Error("시즌 종료 중 오류가 발생했습니다");
+  }
+
+  const rpcResult = data as EndSeasonRpcResponse | null;
+  if (!rpcResult?.success) {
+    throw new Error(rpcResult?.error || "시즌 종료에 실패했습니다");
+  }
+
+  const parsedSeasonId = Number(rpcResult.season_id ?? seasonId);
+  if (!Number.isFinite(parsedSeasonId)) {
+    throw new Error("시즌 종료 응답 형식이 올바르지 않습니다");
+  }
+
+  return {
+    seasonId: parsedSeasonId,
+    status: "ARCHIVED",
+  };
 };
 
 // Admin Functions for Game Management
@@ -796,7 +1067,7 @@ export const getMarketListForDate = async (
   const { data: marketRows, error: marketsError } = await supabase
     .from("markets")
     .select(
-      "id, game_id, status, result, initial_home_price, initial_away_price, initial_draw_price"
+      "id, game_id, status, result, season_id, initial_home_price, initial_away_price, initial_draw_price"
     )
     .in("game_id", gameIds);
 
@@ -880,6 +1151,7 @@ export const getMarketListForDate = async (
         awayTeamShortName: awayTeam.short_name ?? null,
         homeScore: game.home_score ?? null,
         awayScore: game.away_score ?? null,
+        seasonId: market.season_id ?? null,
         prices,
         initialPrices: {
           HOME: toNumberOrNull(market.initial_home_price),
@@ -1046,6 +1318,8 @@ export const getMarketDetail = async (
     awayPitcher: game.away_pitcher ?? null,
     homeScore: toNumberOrNull(game.home_score),
     awayScore: toNumberOrNull(game.away_score),
+    seasonId: toNumberOrNull(market.season_id),
+    seasonName: market.season_name ?? null,
   };
 };
 
@@ -1134,7 +1408,8 @@ export const getPriceSnapshots = async (
 };
 
 export const getOpenPositionsHistory = async (
-  userId: string
+  userId: string,
+  seasonId?: number
 ): Promise<OpenPositionHistoryItem[]> => {
   if (!userId) {
     throw new Error("사용자 정보가 올바르지 않습니다");
@@ -1142,6 +1417,7 @@ export const getOpenPositionsHistory = async (
 
   const { data, error } = await supabase.rpc("get_user_open_positions", {
     p_user_id: userId,
+    p_season_id: seasonId ?? null,
   });
 
   if (error) {
@@ -1209,6 +1485,8 @@ export const getOpenPositionsHistory = async (
       awayTeamName: awayTeam.name,
       homeTeamShortName: homeTeam.short_name ?? null,
       awayTeamShortName: awayTeam.short_name ?? null,
+      seasonId: toNumberOrNull(row.season_id) ?? 0,
+      seasonName: row.season_name ?? "",
     });
   });
 
@@ -1218,14 +1496,16 @@ export const getOpenPositionsHistory = async (
 };
 
 export const getPositions = async (
-  userId: string
+  userId: string,
+  seasonId?: number
 ): Promise<OpenPositionHistoryItem[]> => {
-  return getOpenPositionsHistory(userId);
+  return getOpenPositionsHistory(userId, seasonId);
 };
 
 export const getOrderHistoryByDate = async (
   userId: string,
-  date: string
+  date: string,
+  seasonId?: number
 ): Promise<OrderHistoryItem[]> => {
   if (!userId) {
     throw new Error("사용자 정보가 올바르지 않습니다");
@@ -1236,6 +1516,7 @@ export const getOrderHistoryByDate = async (
     p_user_id: userId,
     p_start_at: startAtIso,
     p_end_at: endAtIso,
+    p_season_id: seasonId ?? null,
   });
 
   if (error) {
@@ -1303,6 +1584,8 @@ export const getOrderHistoryByDate = async (
       awayTeamName: awayTeam.name,
       homeTeamShortName: homeTeam.short_name ?? null,
       awayTeamShortName: awayTeam.short_name ?? null,
+      seasonId: toNumberOrNull(row.season_id) ?? 0,
+      seasonName: row.season_name ?? "",
     });
   });
 
@@ -1313,13 +1596,15 @@ export const getOrderHistoryByDate = async (
 
 export const getOrderHistory = async (
   userId: string,
-  date = getISODate()
+  date = getISODate(),
+  seasonId?: number
 ): Promise<OrderHistoryItem[]> => {
-  return getOrderHistoryByDate(userId, date);
+  return getOrderHistoryByDate(userId, date, seasonId);
 };
 
 export const getSettlementHistory = async (
-  userId: string
+  userId: string,
+  seasonId?: number
 ): Promise<SettlementHistoryItem[]> => {
   if (!userId) {
     throw new Error("사용자 정보가 올바르지 않습니다");
@@ -1327,6 +1612,7 @@ export const getSettlementHistory = async (
 
   const { data, error } = await supabase.rpc("get_user_settlement_history", {
     p_user_id: userId,
+    p_season_id: seasonId ?? null,
   });
 
   if (error) {
@@ -1394,6 +1680,8 @@ export const getSettlementHistory = async (
       awayTeamName: awayTeam.name,
       homeTeamShortName: homeTeam.short_name ?? null,
       awayTeamShortName: awayTeam.short_name ?? null,
+      seasonId: toNumberOrNull(row.season_id) ?? 0,
+      seasonName: row.season_name ?? "",
     });
   });
 
@@ -1907,9 +2195,13 @@ export const getWeeklyCoinCronStatus =
     };
   };
 
-export const getWalletBalance = async (userId: string): Promise<number> => {
+export const getWalletBalance = async (
+  userId: string,
+  seasonId?: number
+): Promise<number> => {
   const { data, error } = await supabase.rpc("get_wallet_balance", {
     p_user_id: userId,
+    p_season_id: seasonId ?? null,
   });
 
   if (error) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -876,7 +876,7 @@ export const getLeaderboardRoi = async (
 
 const parseSeasonFromRpc = (raw: SeasonRpcShape): Season => {
   const parsedId = Number(raw.id);
-  if (!Number.isFinite(parsedId) || parsedId <= 0) {
+  if (!Number.isFinite(parsedId) || parsedId < 0) {
     throw new Error("시즌 데이터 형식이 올바르지 않습니다");
   }
 

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,408 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "lookin"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = false
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260327000022_reset_all_wallet_balances_to_1000.sql
+++ b/supabase/migrations/20260327000022_reset_all_wallet_balances_to_1000.sql
@@ -1,0 +1,8 @@
+-- New season wallet reset: set every existing member wallet balance to 1,000 coins.
+INSERT INTO public.wallets (user_id, balance)
+SELECT u.id, 1000
+FROM public.users u
+ON CONFLICT (user_id)
+DO UPDATE SET
+  balance = EXCLUDED.balance,
+  updated_at = NOW();

--- a/supabase/migrations/20260518000000_us_seasons_schema.sql
+++ b/supabase/migrations/20260518000000_us_seasons_schema.sql
@@ -1,0 +1,343 @@
+-- US-012: 시즌 시스템 - 스키마 및 데이터 백필
+-- 실행 대상: Supabase SQL Editor 또는 `supabase db execute`
+
+-- ============================================================================
+-- 개요
+-- ----------------------------------------------------------------------------
+-- 이 마이그레이션은 ToKHin' LMSR 예측시장 앱에 "시즌(Season)" 개념을 도입한다.
+--
+-- 변경 사항:
+--   1. public.seasons 테이블 신규 추가
+--   2. wallets, markets, orders, positions, transactions 5개 테이블에 season_id 컬럼 추가
+--   3. 기존 데이터를 KST 기준 2026-03-28 0시를 경계로 Season 0 / Season 1 로 백필
+--   4. wallets UNIQUE 제약을 (user_id) → (user_id, season_id) 로 교체
+--      (Section 5e-step2 에서 Season 0 지갑 INSERT 이전에 선행하여 교체한다.
+--       그래야 동일 user_id 에 대해 Season 0 / Season 1 두 지갑이 공존할 수 있다.
+--       Section 8 은 해당 교체가 완료되었는지 재확인하는 idempotent 가드로 축소.)
+--   5. Season 0 / Season 1 백필 지갑에 대해 SEASON_GRANT 트랜잭션 동기화
+--   6. transactions.type CHECK 제약에 'SEASON_GRANT' 추가
+--
+-- 시즌 시드 데이터:
+--   - Season 0 (id=0): 2026-03-28 KST 이전의 모든 레거시 데이터 버킷, status=ARCHIVED
+--   - Season 1 (id=1): 2026-03-28 부터 현재까지 활성 시즌, status=ACTIVE
+--   - Season 2 (id=2): 2026-05-19 ~ 2026-06-21 예정 시즌, status=DRAFT (관리자 수동 활성화)
+--
+-- RPC 함수 수정은 본 마이그레이션에 포함하지 않으며,
+-- 후속 마이그레이션 20260518000001 에서 별도로 처리한다.
+-- ============================================================================
+
+
+-- ============================================================================
+-- Section 2: public.seasons 테이블 생성
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.seasons (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR NOT NULL UNIQUE,
+  start_date DATE,
+  end_date DATE,
+  status VARCHAR NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT', 'ACTIVE', 'ARCHIVED')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DROP TRIGGER IF EXISTS trg_seasons_set_updated_at ON public.seasons;
+CREATE TRIGGER trg_seasons_set_updated_at
+BEFORE UPDATE ON public.seasons
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+-- ACTIVE 시즌은 동시에 1개만 존재해야 함
+CREATE UNIQUE INDEX IF NOT EXISTS seasons_one_active
+  ON public.seasons (status) WHERE status = 'ACTIVE';
+
+-- DRAFT 시즌도 동시에 1개만 존재해야 함
+CREATE UNIQUE INDEX IF NOT EXISTS seasons_one_draft
+  ON public.seasons (status) WHERE status = 'DRAFT';
+
+-- RLS 활성화 + 공개 SELECT 정책 (다른 public 테이블과 일관)
+ALTER TABLE public.seasons ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS seasons_select_all ON public.seasons;
+CREATE POLICY seasons_select_all ON public.seasons FOR SELECT USING (TRUE);
+
+GRANT SELECT ON public.seasons TO anon, authenticated;
+GRANT USAGE, SELECT ON SEQUENCE public.seasons_id_seq TO anon, authenticated;
+
+
+-- ============================================================================
+-- Section 3: 시즌 시드 데이터 (명시적 ID 0, 1, 2)
+-- ============================================================================
+
+INSERT INTO public.seasons (id, name, start_date, end_date, status, created_at, updated_at)
+VALUES
+  (0, 'Season 0', NULL, DATE '2026-03-27', 'ARCHIVED', NOW(), NOW()),
+  (1, 'Season 1', DATE '2026-03-28', NULL, 'ACTIVE', NOW(), NOW()),
+  (2, 'Season 2', DATE '2026-05-19', DATE '2026-06-21', 'DRAFT', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- 시퀀스를 재설정해서 다음 자동 ID 가 3 부터 시작하도록 보정
+SELECT setval(
+  'public.seasons_id_seq',
+  GREATEST(2, (SELECT COALESCE(MAX(id), 0) FROM public.seasons))
+);
+
+
+-- ============================================================================
+-- Section 4: 5개 테이블에 nullable season_id 컬럼 추가
+-- ============================================================================
+
+ALTER TABLE public.wallets       ADD COLUMN IF NOT EXISTS season_id INTEGER REFERENCES public.seasons(id) ON DELETE RESTRICT;
+ALTER TABLE public.markets       ADD COLUMN IF NOT EXISTS season_id INTEGER REFERENCES public.seasons(id) ON DELETE RESTRICT;
+ALTER TABLE public.orders        ADD COLUMN IF NOT EXISTS season_id INTEGER REFERENCES public.seasons(id) ON DELETE RESTRICT;
+ALTER TABLE public.positions     ADD COLUMN IF NOT EXISTS season_id INTEGER REFERENCES public.seasons(id) ON DELETE RESTRICT;
+ALTER TABLE public.transactions  ADD COLUMN IF NOT EXISTS season_id INTEGER REFERENCES public.seasons(id) ON DELETE RESTRICT;
+
+
+-- ============================================================================
+-- Section 5: season_id 백필
+-- ----------------------------------------------------------------------------
+-- 컷오프: 2026-03-28 00:00 KST = 2026-03-27 15:00 UTC
+--   - games.game_date < 2026-03-28        → Season 0
+--   - games.game_date >= 2026-03-28       → Season 1
+--   - transactions.created_at < 컷오프(UTC) → Season 0
+--
+-- 5e (wallets) 는 3단계로 진행한다:
+--   step1) 기존 wallets 모두 season_id=1 로 표시
+--   step2) wallets UNIQUE 제약을 (user_id) → (user_id, season_id) 로 선행 교체
+--          (없으면 step3 INSERT 가 기존 (user_id) UNIQUE 와 충돌하여 silent no-op)
+--   step3) pre-cutoff 거래 보유 사용자에게 Season 0 지갑 INSERT
+--          (ON CONFLICT 타겟을 (user_id, season_id) 로 명시하여 멱등성 확보)
+-- ============================================================================
+
+-- 5a) markets.season_id ← games.game_date
+UPDATE public.markets m
+SET season_id = CASE
+  WHEN g.game_date < DATE '2026-03-28' THEN 0
+  ELSE 1
+END
+FROM public.games g
+WHERE g.id = m.game_id AND m.season_id IS NULL;
+
+-- 5b) orders.season_id ← markets.season_id
+UPDATE public.orders o
+SET season_id = m.season_id
+FROM public.markets m
+WHERE m.id = o.market_id AND o.season_id IS NULL;
+
+-- 5c) positions.season_id ← markets.season_id
+UPDATE public.positions p
+SET season_id = m.season_id
+FROM public.markets m
+WHERE m.id = p.market_id AND p.season_id IS NULL;
+
+-- 5d) transactions.season_id ← created_at 컷오프
+UPDATE public.transactions t
+SET season_id = CASE
+  WHEN t.created_at < TIMESTAMPTZ '2026-03-27 15:00:00+00' THEN 0
+  ELSE 1
+END
+WHERE t.season_id IS NULL;
+
+-- 5e-step1) 기존 wallets 행은 모두 Season 1 지갑으로 간주
+UPDATE public.wallets
+SET season_id = 1, updated_at = NOW()
+WHERE season_id IS NULL;
+
+-- 5e-step2) wallets UNIQUE 제약을 (user_id) → (user_id, season_id) 로 선행 교체
+--           이 단계가 없으면 step3 INSERT 가 기존 wallets_user_id_key (user_id) UNIQUE
+--           와 충돌하여 ON CONFLICT 로 silently no-op 된다. 결과적으로 Season 0 지갑이
+--           하나도 생성되지 않아 데이터 무결성이 깨진다.
+--           NOT NULL 강제는 Section 7 까지 미루므로, 이 시점에서는 season_id NULL 행도
+--           이론상 허용되지만, Section 5d 까지 transactions 가 모두 백필되었기 때문에
+--           실질적으로 NULL 행은 더 이상 없다.
+ALTER TABLE public.wallets DROP CONSTRAINT IF EXISTS wallets_user_id_key;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'wallets_user_season_key'
+      AND conrelid = 'public.wallets'::regclass
+  ) THEN
+    ALTER TABLE public.wallets
+      ADD CONSTRAINT wallets_user_season_key UNIQUE (user_id, season_id);
+  END IF;
+END $$;
+
+-- 5e-step3) pre-cutoff 트랜잭션이 있는 사용자에게 Season 0 지갑 생성
+--           잔고는 해당 사용자의 가장 마지막 pre-cutoff 트랜잭션의 balance_after 사용.
+--           이 시점에 wallets UNIQUE 는 (user_id, season_id) 이므로 ON CONFLICT 타겟을
+--           명시적으로 (user_id, season_id) 로 지정하여 재실행 시에도 멱등성을 보장한다.
+INSERT INTO public.wallets (user_id, season_id, balance, created_at, updated_at)
+SELECT DISTINCT ON (t.user_id)
+  t.user_id,
+  0 AS season_id,
+  t.balance_after,
+  NOW(),
+  NOW()
+FROM public.transactions t
+WHERE t.created_at < TIMESTAMPTZ '2026-03-27 15:00:00+00'
+ORDER BY t.user_id, t.created_at DESC, t.id DESC
+ON CONFLICT (user_id, season_id) DO NOTHING;
+
+
+-- ============================================================================
+-- Section 6: SEASON_GRANT 트랜잭션 동기화 + type CHECK 확장
+-- ============================================================================
+
+-- 6a) transactions.type CHECK 제약 확장: SEASON_GRANT 허용
+ALTER TABLE public.transactions DROP CONSTRAINT IF EXISTS transactions_type_check;
+ALTER TABLE public.transactions ADD CONSTRAINT transactions_type_check
+  CHECK (type IN ('BUY', 'SELL', 'SETTLEMENT', 'WEEKLY_GRANT', 'ADMIN_GRANT', 'SEASON_GRANT'));
+
+-- 6b) Season 0 지갑 보유 사용자에게 SEASON_GRANT (1000) 합성
+--     이미 동일 (user_id, season_id=0, type='SEASON_GRANT') 트랜잭션이 있으면 스킵 → 멱등성
+INSERT INTO public.transactions (user_id, type, amount, balance_after, reference_id, description, created_at, season_id)
+SELECT
+  w.user_id,
+  'SEASON_GRANT',
+  1000,
+  1000,
+  NULL,
+  'Season 0 시작 코인 지급 (백필)',
+  TIMESTAMPTZ '2026-02-24 00:00:00+09',
+  0
+FROM public.wallets w
+WHERE w.season_id = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM public.transactions t
+    WHERE t.user_id = w.user_id
+      AND t.season_id = 0
+      AND t.type = 'SEASON_GRANT'
+  );
+
+-- 6c) Season 1 지갑 보유 사용자에게 SEASON_GRANT (1000) 합성
+INSERT INTO public.transactions (user_id, type, amount, balance_after, reference_id, description, created_at, season_id)
+SELECT
+  w.user_id,
+  'SEASON_GRANT',
+  1000,
+  1000,
+  NULL,
+  'Season 1 시작 코인 지급 (백필)',
+  TIMESTAMPTZ '2026-03-28 00:00:00+09',
+  1
+FROM public.wallets w
+WHERE w.season_id = 1
+  AND NOT EXISTS (
+    SELECT 1 FROM public.transactions t
+    WHERE t.user_id = w.user_id
+      AND t.season_id = 1
+      AND t.type = 'SEASON_GRANT'
+  );
+
+
+-- ============================================================================
+-- Section 7: NOT NULL 강제 + 백필 검증
+-- ============================================================================
+
+-- NULL 행이 남아 있으면 즉시 실패시켜 트랜잭션 롤백
+DO $$
+DECLARE
+  v_null_wallets       BIGINT;
+  v_null_markets       BIGINT;
+  v_null_orders        BIGINT;
+  v_null_positions     BIGINT;
+  v_null_transactions  BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO v_null_wallets       FROM public.wallets       WHERE season_id IS NULL;
+  SELECT COUNT(*) INTO v_null_markets       FROM public.markets       WHERE season_id IS NULL;
+  SELECT COUNT(*) INTO v_null_orders        FROM public.orders        WHERE season_id IS NULL;
+  SELECT COUNT(*) INTO v_null_positions     FROM public.positions     WHERE season_id IS NULL;
+  SELECT COUNT(*) INTO v_null_transactions  FROM public.transactions  WHERE season_id IS NULL;
+
+  IF v_null_wallets > 0 THEN
+    RAISE EXCEPTION 'season_id가 NULL인 wallets 행이 %개 존재합니다', v_null_wallets;
+  END IF;
+  IF v_null_markets > 0 THEN
+    RAISE EXCEPTION 'season_id가 NULL인 markets 행이 %개 존재합니다', v_null_markets;
+  END IF;
+  IF v_null_orders > 0 THEN
+    RAISE EXCEPTION 'season_id가 NULL인 orders 행이 %개 존재합니다', v_null_orders;
+  END IF;
+  IF v_null_positions > 0 THEN
+    RAISE EXCEPTION 'season_id가 NULL인 positions 행이 %개 존재합니다', v_null_positions;
+  END IF;
+  IF v_null_transactions > 0 THEN
+    RAISE EXCEPTION 'season_id가 NULL인 transactions 행이 %개 존재합니다', v_null_transactions;
+  END IF;
+END $$;
+
+ALTER TABLE public.wallets       ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE public.markets       ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE public.orders        ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE public.positions     ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE public.transactions  ALTER COLUMN season_id SET NOT NULL;
+
+
+-- ============================================================================
+-- Section 8: wallets UNIQUE 제약 상태 검증
+-- ----------------------------------------------------------------------------
+-- 제약 교체는 Section 5e-step2 에서 이미 완료되었다. 본 섹션은 최종 상태를 재확인하는
+-- idempotent 가드이며, 어떤 이유로든 교체가 누락된 경우 즉시 마이그레이션을 중단시킨다.
+-- ============================================================================
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'wallets_user_id_key'
+      AND conrelid = 'public.wallets'::regclass
+  ) THEN
+    RAISE EXCEPTION 'wallets_user_id_key 제약이 아직 존재합니다 (Section 5e-step2 미실행)';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'wallets_user_season_key'
+      AND conrelid = 'public.wallets'::regclass
+  ) THEN
+    RAISE EXCEPTION 'wallets_user_season_key UNIQUE 제약이 누락되었습니다 (Section 5e-step2 미실행)';
+  END IF;
+END $$;
+
+
+-- ============================================================================
+-- Section 9: 성능용 인덱스
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_markets_season            ON public.markets       (season_id);
+CREATE INDEX IF NOT EXISTS idx_orders_user_season        ON public.orders        (user_id, season_id);
+CREATE INDEX IF NOT EXISTS idx_positions_user_season     ON public.positions     (user_id, season_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_user_season  ON public.transactions  (user_id, season_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_season_type  ON public.transactions  (season_id, type);
+CREATE INDEX IF NOT EXISTS idx_wallets_season            ON public.wallets       (season_id);
+
+
+-- ============================================================================
+-- Section 10: 최종 무결성 검증
+-- ============================================================================
+
+DO $$
+DECLARE
+  v_season_count  INTEGER;
+  v_active_count  INTEGER;
+  v_draft_count   INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_season_count FROM public.seasons;
+  SELECT COUNT(*) INTO v_active_count FROM public.seasons WHERE status = 'ACTIVE';
+  SELECT COUNT(*) INTO v_draft_count  FROM public.seasons WHERE status = 'DRAFT';
+
+  IF v_season_count < 3 THEN
+    RAISE EXCEPTION 'seasons 테이블에 3개의 시즌이 모두 존재해야 합니다 (현재: %)', v_season_count;
+  END IF;
+  IF v_active_count <> 1 THEN
+    RAISE EXCEPTION 'ACTIVE 시즌이 정확히 1개여야 합니다 (현재: %)', v_active_count;
+  END IF;
+  IF v_draft_count <> 1 THEN
+    RAISE EXCEPTION 'DRAFT 시즌이 정확히 1개여야 합니다 (현재: %)', v_draft_count;
+  END IF;
+
+  RAISE NOTICE '시즌 시스템 스키마 마이그레이션 완료: 시즌 %개, ACTIVE %개, DRAFT %개',
+    v_season_count, v_active_count, v_draft_count;
+END $$;

--- a/supabase/migrations/20260518000001_us_seasons_rpcs.sql
+++ b/supabase/migrations/20260518000001_us_seasons_rpcs.sql
@@ -1,0 +1,2252 @@
+-- US-012: 시즌 시스템 - RPC 함수 추가/수정
+-- 실행 대상: Supabase SQL Editor 또는 `supabase db execute`
+-- 이 마이그레이션은 20260518000000_us_seasons_schema.sql 적용 후 실행되어야 한다.
+
+-- ============================================================================
+-- 시즌 인지(season-aware) RPC 계약 요약
+-- ----------------------------------------------------------------------------
+--   - 거래/지갑/정산은 항상 v_market.season_id 에 귀속된
+--     지갑/주문/포지션/트랜잭션에서만 이루어진다.
+--   - ACTIVE 시즌이 아닌 시즌의 마켓은 거래/정산이 모두 차단된다.
+--   - 리더보드/히스토리는 p_season_id DEFAULT NULL 을 받아
+--     NULL 이면 현재 ACTIVE 시즌으로 자동 해결한다.
+--   - 보존되는 불변 규칙: 폐장 시간(KST 01:00~09:00), 30분 매도 쿨다운,
+--     LMSR 수식, KST 타임존, purchased_at 업데이트.
+-- ============================================================================
+
+
+-- ============================================================================
+-- SECTION A: 시즌 라이프사이클 RPC
+-- ============================================================================
+
+-- A1. get_active_season: 현재 ACTIVE 시즌 조회
+CREATE OR REPLACE FUNCTION public.get_active_season()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_season public.seasons%ROWTYPE;
+BEGIN
+  SELECT *
+  INTO v_season
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', '활성 시즌이 없습니다'
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'season', jsonb_build_object(
+      'id', v_season.id,
+      'name', v_season.name,
+      'start_date', v_season.start_date,
+      'end_date', v_season.end_date,
+      'status', v_season.status
+    )
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- A2. list_seasons: 전체 시즌 목록 (ID DESC)
+CREATE OR REPLACE FUNCTION public.list_seasons()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_seasons JSONB;
+BEGIN
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', s.id,
+        'name', s.name,
+        'start_date', s.start_date,
+        'end_date', s.end_date,
+        'status', s.status,
+        'created_at', s.created_at
+      )
+      ORDER BY s.id DESC
+    ),
+    '[]'::JSONB
+  )
+  INTO v_seasons
+  FROM public.seasons s;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'seasons', v_seasons
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- A3. create_season: 신규 DRAFT 시즌 생성
+CREATE OR REPLACE FUNCTION public.create_season(
+  p_name TEXT,
+  p_start_date DATE,
+  p_end_date DATE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_name TEXT;
+  v_existing_draft_count INTEGER;
+  v_season public.seasons%ROWTYPE;
+BEGIN
+  v_name := BTRIM(COALESCE(p_name, ''));
+
+  IF v_name = '' THEN
+    RAISE EXCEPTION '시즌 이름이 비어 있습니다';
+  END IF;
+
+  IF p_start_date IS NULL OR p_end_date IS NULL THEN
+    RAISE EXCEPTION '시즌 시작일과 종료일은 모두 입력해야 합니다';
+  END IF;
+
+  IF p_start_date >= p_end_date THEN
+    RAISE EXCEPTION '시즌 시작일은 종료일보다 이전이어야 합니다';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_existing_draft_count
+  FROM public.seasons
+  WHERE status = 'DRAFT';
+
+  IF v_existing_draft_count > 0 THEN
+    RAISE EXCEPTION '이미 DRAFT 상태의 시즌이 존재합니다. 활성화 또는 정리 후 새 시즌을 생성해주세요';
+  END IF;
+
+  INSERT INTO public.seasons (name, start_date, end_date, status, created_at, updated_at)
+  VALUES (v_name, p_start_date, p_end_date, 'DRAFT', NOW(), NOW())
+  RETURNING * INTO v_season;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'season', jsonb_build_object(
+      'id', v_season.id,
+      'name', v_season.name,
+      'start_date', v_season.start_date,
+      'end_date', v_season.end_date,
+      'status', v_season.status,
+      'created_at', v_season.created_at
+    )
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- A4. activate_season: DRAFT → ACTIVE 전환 + 이전 ACTIVE → ARCHIVED + 신규 시즌 코인 지급
+CREATE OR REPLACE FUNCTION public.activate_season(
+  p_season_id INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_target public.seasons%ROWTYPE;
+  v_active public.seasons%ROWTYPE;
+  v_pending_count INTEGER := 0;
+  v_pending_ids TEXT;
+  v_users_granted INTEGER := 0;
+  v_user_row RECORD;
+  v_inserted_wallet_id UUID;
+BEGIN
+  IF p_season_id IS NULL THEN
+    RAISE EXCEPTION '시즌 정보가 올바르지 않습니다';
+  END IF;
+
+  -- 1) 대상 시즌 잠금 + 상태 검증
+  SELECT *
+  INTO v_target
+  FROM public.seasons
+  WHERE id = p_season_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '시즌을 찾을 수 없습니다';
+  END IF;
+
+  IF v_target.status <> 'DRAFT' THEN
+    RAISE EXCEPTION '해당 시즌은 활성화 가능한 DRAFT 상태가 아닙니다';
+  END IF;
+
+  -- 2) 현재 ACTIVE 시즌 잠금 (있을 경우)
+  SELECT *
+  INTO v_active
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  FOR UPDATE;
+
+  -- 3) 이전 시즌에 미정산 마켓이 있는지 확인
+  IF FOUND THEN
+    SELECT COUNT(*)
+    INTO v_pending_count
+    FROM public.markets
+    WHERE season_id = v_active.id
+      AND status IN ('OPEN', 'CLOSED');
+
+    IF v_pending_count > 0 THEN
+      SELECT string_agg(id::TEXT, ', ' ORDER BY id)
+      INTO v_pending_ids
+      FROM (
+        SELECT id
+        FROM public.markets
+        WHERE season_id = v_active.id
+          AND status IN ('OPEN', 'CLOSED')
+        ORDER BY id
+        LIMIT 5
+      ) sub;
+
+      RAISE EXCEPTION '이전 시즌에 정산되지 않은 마켓이 %개 있습니다 (마켓 ID: %)',
+        v_pending_count, v_pending_ids;
+    END IF;
+
+    -- 4) 이전 ACTIVE → ARCHIVED
+    UPDATE public.seasons
+    SET
+      status = 'ARCHIVED',
+      end_date = CURRENT_DATE,
+      updated_at = NOW()
+    WHERE id = v_active.id;
+  END IF;
+
+  -- 5) 대상 DRAFT → ACTIVE
+  UPDATE public.seasons
+  SET
+    status = 'ACTIVE',
+    updated_at = NOW()
+  WHERE id = v_target.id;
+
+  -- 6) 신규 시즌 지갑 생성 (balance=1000) 및 SEASON_GRANT 트랜잭션 기록
+  --    ON CONFLICT (user_id, season_id) 가드를 통해 재실행 시 멱등성 확보
+  FOR v_user_row IN
+    SELECT id AS user_id FROM public.users
+  LOOP
+    v_inserted_wallet_id := NULL;
+
+    INSERT INTO public.wallets (user_id, season_id, balance, created_at, updated_at)
+    VALUES (v_user_row.user_id, p_season_id, 1000, NOW(), NOW())
+    ON CONFLICT (user_id, season_id) DO NOTHING
+    RETURNING id INTO v_inserted_wallet_id;
+
+    IF v_inserted_wallet_id IS NOT NULL THEN
+      INSERT INTO public.transactions (
+        user_id, type, amount, balance_after, reference_id,
+        description, created_at, season_id
+      )
+      VALUES (
+        v_user_row.user_id, 'SEASON_GRANT', 1000, 1000, NULL,
+        '시즌 시작 코인 지급', NOW(), p_season_id
+      );
+
+      v_users_granted := v_users_granted + 1;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'season_id', p_season_id,
+    'users_granted', v_users_granted
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- A5. end_season: ACTIVE → ARCHIVED (미정산 마켓 있으면 차단)
+CREATE OR REPLACE FUNCTION public.end_season(
+  p_season_id INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_season public.seasons%ROWTYPE;
+  v_pending_count INTEGER := 0;
+  v_pending_ids TEXT;
+BEGIN
+  IF p_season_id IS NULL THEN
+    RAISE EXCEPTION '시즌 정보가 올바르지 않습니다';
+  END IF;
+
+  SELECT *
+  INTO v_season
+  FROM public.seasons
+  WHERE id = p_season_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '시즌을 찾을 수 없습니다';
+  END IF;
+
+  IF v_season.status <> 'ACTIVE' THEN
+    RAISE EXCEPTION '해당 시즌은 ACTIVE 상태가 아니므로 종료할 수 없습니다';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_pending_count
+  FROM public.markets
+  WHERE season_id = p_season_id
+    AND status IN ('OPEN', 'CLOSED');
+
+  IF v_pending_count > 0 THEN
+    SELECT string_agg(id::TEXT, ', ' ORDER BY id)
+    INTO v_pending_ids
+    FROM (
+      SELECT id
+      FROM public.markets
+      WHERE season_id = p_season_id
+        AND status IN ('OPEN', 'CLOSED')
+      ORDER BY id
+      LIMIT 5
+    ) sub;
+
+    RAISE EXCEPTION '이전 시즌에 정산되지 않은 마켓이 %개 있습니다 (마켓 ID: %)',
+      v_pending_count, v_pending_ids;
+  END IF;
+
+  UPDATE public.seasons
+  SET
+    status = 'ARCHIVED',
+    end_date = CURRENT_DATE,
+    updated_at = NOW()
+  WHERE id = p_season_id;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'season_id', p_season_id,
+    'status', 'ARCHIVED'
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- ============================================================================
+-- SECTION B: 지갑/지급 RPC 업데이트
+-- ============================================================================
+
+-- B1. login: 인증 + 활성 시즌 지갑 자동 생성 + SEASON_GRANT
+CREATE OR REPLACE FUNCTION public.login(
+  p_student_number BIGINT,
+  p_password TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_user RECORD;
+  v_input_hash TEXT;
+  v_active public.seasons%ROWTYPE;
+  v_inserted_wallet_id UUID;
+BEGIN
+  SELECT id, username, password_hash, password_changed
+  INTO v_user
+  FROM public.users
+  WHERE student_number = p_student_number
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', '학번 또는 비밀번호가 올바르지 않습니다'
+    );
+  END IF;
+
+  v_input_hash := encode(digest(COALESCE(p_password, ''), 'sha256'), 'hex');
+
+  IF v_user.password_hash IS NULL OR v_user.password_hash <> v_input_hash THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', '학번 또는 비밀번호가 올바르지 않습니다'
+    );
+  END IF;
+
+  -- 활성 시즌 조회
+  SELECT *
+  INTO v_active
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'login 처리 중 활성 시즌을 찾을 수 없습니다'
+    );
+  END IF;
+
+  -- 활성 시즌 지갑 자동 생성 (balance=1000) + SEASON_GRANT
+  v_inserted_wallet_id := NULL;
+
+  INSERT INTO public.wallets (user_id, season_id, balance, created_at, updated_at)
+  VALUES (v_user.id, v_active.id, 1000, NOW(), NOW())
+  ON CONFLICT (user_id, season_id) DO NOTHING
+  RETURNING id INTO v_inserted_wallet_id;
+
+  IF v_inserted_wallet_id IS NOT NULL THEN
+    INSERT INTO public.transactions (
+      user_id, type, amount, balance_after, reference_id,
+      description, created_at, season_id
+    )
+    VALUES (
+      v_user.id, 'SEASON_GRANT', 1000, 1000, NULL,
+      '시즌 시작 코인 지급', NOW(), v_active.id
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'user_id', v_user.id,
+    'username', v_user.username,
+    'password_changed', COALESCE(v_user.password_changed, FALSE)
+  );
+END;
+$$;
+
+
+-- B2. get_wallet_balance: 활성 시즌 또는 지정 시즌 잔고 조회
+DROP FUNCTION IF EXISTS public.get_wallet_balance(UUID);
+CREATE OR REPLACE FUNCTION public.get_wallet_balance(
+  p_user_id UUID,
+  p_season_id INTEGER DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_season_id INTEGER;
+  v_balance NUMERIC;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_season_id IS NULL THEN
+    SELECT id INTO v_season_id
+    FROM public.seasons
+    WHERE status = 'ACTIVE'
+    LIMIT 1;
+
+    IF v_season_id IS NULL THEN
+      RAISE EXCEPTION '활성 시즌이 없습니다';
+    END IF;
+  ELSE
+    v_season_id := p_season_id;
+  END IF;
+
+  SELECT balance
+  INTO v_balance
+  FROM public.wallets
+  WHERE user_id = p_user_id
+    AND season_id = v_season_id
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    -- 시즌 중 미가입 사용자도 호출 가능하므로 0 으로 응답 (예외 아님)
+    RETURN jsonb_build_object(
+      'success', TRUE,
+      'balance', 0,
+      'season_id', v_season_id
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'balance', v_balance,
+    'season_id', v_season_id
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- B3. distribute_weekly_coins: 활성 시즌 지갑에 주간 코인 지급
+--     pg_cron weekly_coin_distribution 작업이 호출하므로 시그니처 (p_amount DEFAULT 300) 고정.
+CREATE OR REPLACE FUNCTION public.distribute_weekly_coins(
+  p_amount NUMERIC DEFAULT 300
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_active public.seasons%ROWTYPE;
+  v_users_count INTEGER := 0;
+  v_total_distributed NUMERIC := 0;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION '지급 코인은 0보다 커야 합니다';
+  END IF;
+
+  SELECT *
+  INTO v_active
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '활성 시즌이 없어 주간 코인을 지급할 수 없습니다';
+  END IF;
+
+  -- 활성 시즌 지갑이 없는 사용자에게 잔고 0 지갑을 선제 생성 (방어적)
+  INSERT INTO public.wallets (user_id, season_id, balance, created_at, updated_at)
+  SELECT u.id, v_active.id, 0, NOW(), NOW()
+  FROM public.users u
+  ON CONFLICT (user_id, season_id) DO NOTHING;
+
+  -- 활성 시즌 지갑에 한해 잔고 + p_amount, 트랜잭션 동시 INSERT
+  WITH updated_wallets AS (
+    UPDATE public.wallets w
+    SET
+      balance = w.balance + p_amount,
+      updated_at = NOW()
+    FROM public.users u
+    WHERE u.id = w.user_id
+      AND w.season_id = v_active.id
+    RETURNING w.user_id, w.balance
+  ), inserted_transactions AS (
+    INSERT INTO public.transactions (
+      user_id, type, amount, balance_after, reference_id,
+      description, season_id
+    )
+    SELECT
+      uw.user_id, 'WEEKLY_GRANT', p_amount, uw.balance, NULL,
+      '주간 코인 지급', v_active.id
+    FROM updated_wallets uw
+    RETURNING user_id
+  )
+  SELECT
+    COUNT(*),
+    COALESCE(COUNT(*) * p_amount, 0)
+  INTO v_users_count, v_total_distributed
+  FROM inserted_transactions;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'users_count', v_users_count,
+    'total_distributed', v_total_distributed
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- B4. admin_grant_coins: 활성 시즌 지갑에 단건 지급
+CREATE OR REPLACE FUNCTION public.admin_grant_coins(
+  p_user_id UUID,
+  p_amount NUMERIC
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_active public.seasons%ROWTYPE;
+  v_wallet public.wallets%ROWTYPE;
+  v_new_balance NUMERIC;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION '지급 코인은 0보다 커야 합니다';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.users WHERE id = p_user_id) THEN
+    RAISE EXCEPTION '사용자 정보를 찾을 수 없습니다';
+  END IF;
+
+  SELECT *
+  INTO v_active
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  -- 활성 시즌 지갑 잠금 (없으면 0 잔고 INSERT 후 재잠금)
+  SELECT *
+  INTO v_wallet
+  FROM public.wallets
+  WHERE user_id = p_user_id
+    AND season_id = v_active.id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.wallets (user_id, season_id, balance, created_at, updated_at)
+    VALUES (p_user_id, v_active.id, 0, NOW(), NOW())
+    ON CONFLICT (user_id, season_id) DO NOTHING;
+
+    SELECT *
+    INTO v_wallet
+    FROM public.wallets
+    WHERE user_id = p_user_id
+      AND season_id = v_active.id
+    FOR UPDATE;
+  END IF;
+
+  v_new_balance := v_wallet.balance + p_amount;
+
+  UPDATE public.wallets
+  SET
+    balance = v_new_balance,
+    updated_at = NOW()
+  WHERE id = v_wallet.id;
+
+  INSERT INTO public.transactions (
+    user_id, type, amount, balance_after, reference_id,
+    description, season_id
+  )
+  VALUES (
+    p_user_id, 'ADMIN_GRANT', p_amount, v_new_balance, NULL,
+    '관리자 코인 지급', v_active.id
+  );
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'user_id', p_user_id,
+    'granted_amount', p_amount,
+    'new_balance', v_new_balance
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- ============================================================================
+-- SECTION C: LMSR 거래 RPC 업데이트
+-- ============================================================================
+-- 보존: 폐장 시간 (KST 01:00 ~ 09:00), 30분 매도 쿨다운, LMSR 비용 계산, purchased_at
+-- 추가: 시즌 일치 검증 (이 시즌은 더 이상 거래할 수 없습니다)
+-- 변경: 지갑/주문/포지션/트랜잭션 모두 v_market.season_id 에 귀속
+-- ============================================================================
+
+-- C1. execute_buy_order: 시즌 인지 매수
+CREATE OR REPLACE FUNCTION public.execute_buy_order(
+  p_user_id UUID,
+  p_market_id INTEGER,
+  p_outcome TEXT,
+  p_quantity NUMERIC
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_outcome TEXT;
+  v_market public.markets%ROWTYPE;
+  v_active_season_id INTEGER;
+  v_wallet public.wallets%ROWTYPE;
+  v_position public.positions%ROWTYPE;
+  v_new_q_home NUMERIC;
+  v_new_q_away NUMERIC;
+  v_new_q_draw NUMERIC;
+  v_cost_before NUMERIC;
+  v_cost_after NUMERIC;
+  v_total_cost NUMERIC;
+  v_avg_price NUMERIC;
+  v_new_balance NUMERIC;
+  v_new_position_qty NUMERIC;
+  v_new_avg_entry_price NUMERIC;
+  v_order_id INTEGER;
+BEGIN
+  -- 폐장 시간 체크 (KST 01:00 ~ 09:00)
+  IF EXTRACT(HOUR FROM (NOW() AT TIME ZONE 'Asia/Seoul')) >= 1
+     AND EXTRACT(HOUR FROM (NOW() AT TIME ZONE 'Asia/Seoul')) < 9 THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', '폐장 시간입니다 (새벽 1시 ~ 오전 9시). 오전 9시 이후에 거래해주세요.'
+    );
+  END IF;
+
+  v_outcome := UPPER(BTRIM(COALESCE(p_outcome, '')));
+
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_quantity IS NULL OR p_quantity <= 0 THEN
+    RAISE EXCEPTION '매수 수량은 0보다 커야 합니다';
+  END IF;
+
+  IF v_outcome NOT IN ('HOME', 'AWAY', 'DRAW') THEN
+    RAISE EXCEPTION 'outcome은 HOME, AWAY, DRAW 중 하나여야 합니다';
+  END IF;
+
+  SELECT *
+  INTO v_market
+  FROM public.markets
+  WHERE id = p_market_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  IF v_market.status <> 'OPEN' THEN
+    RAISE EXCEPTION '현재 거래할 수 없는 마켓입니다';
+  END IF;
+
+  -- 시즌 검증: 마켓의 시즌이 현재 ACTIVE 시즌이어야 거래 가능
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  IF v_market.season_id <> v_active_season_id THEN
+    RAISE EXCEPTION '이 시즌은 더 이상 거래할 수 없습니다';
+  END IF;
+
+  v_new_q_home := v_market.q_home;
+  v_new_q_away := v_market.q_away;
+  v_new_q_draw := v_market.q_draw;
+
+  CASE v_outcome
+    WHEN 'HOME' THEN v_new_q_home := v_new_q_home + p_quantity;
+    WHEN 'AWAY' THEN v_new_q_away := v_new_q_away + p_quantity;
+    WHEN 'DRAW' THEN v_new_q_draw := v_new_q_draw + p_quantity;
+  END CASE;
+
+  v_cost_before := public.lmsr_cost(v_market.q_home, v_market.q_away, v_market.q_draw, v_market.b);
+  v_cost_after := public.lmsr_cost(v_new_q_home, v_new_q_away, v_new_q_draw, v_market.b);
+  v_total_cost := 100 * (v_cost_after - v_cost_before);
+
+  IF v_total_cost <= 0 THEN
+    RAISE EXCEPTION '주문 비용 계산에 실패했습니다';
+  END IF;
+
+  v_avg_price := v_total_cost / p_quantity;
+
+  -- 시즌 인지 지갑 잠금
+  SELECT *
+  INTO v_wallet
+  FROM public.wallets
+  WHERE user_id = p_user_id
+    AND season_id = v_market.season_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '지갑 정보를 찾을 수 없습니다';
+  END IF;
+
+  IF v_wallet.balance < v_total_cost THEN
+    RAISE EXCEPTION '잔고가 부족합니다';
+  END IF;
+
+  v_new_balance := v_wallet.balance - v_total_cost;
+
+  UPDATE public.wallets
+  SET
+    balance = v_new_balance,
+    updated_at = NOW()
+  WHERE id = v_wallet.id;
+
+  UPDATE public.markets
+  SET
+    q_home = v_new_q_home,
+    q_away = v_new_q_away,
+    q_draw = v_new_q_draw,
+    updated_at = NOW()
+  WHERE id = v_market.id;
+
+  SELECT *
+  INTO v_position
+  FROM public.positions
+  WHERE user_id = p_user_id
+    AND market_id = p_market_id
+    AND outcome = v_outcome
+  FOR UPDATE;
+
+  IF FOUND THEN
+    v_new_position_qty := v_position.quantity + p_quantity;
+    v_new_avg_entry_price := (
+      (v_position.quantity * v_position.avg_entry_price) +
+      (p_quantity * v_avg_price)
+    ) / v_new_position_qty;
+
+    UPDATE public.positions
+    SET
+      quantity = v_new_position_qty,
+      avg_entry_price = v_new_avg_entry_price,
+      purchased_at = NOW(),
+      updated_at = NOW()
+    WHERE id = v_position.id;
+  ELSE
+    INSERT INTO public.positions (
+      user_id, market_id, outcome, quantity, avg_entry_price,
+      purchased_at, updated_at, season_id
+    )
+    VALUES (
+      p_user_id, p_market_id, v_outcome, p_quantity, v_avg_price,
+      NOW(), NOW(), v_market.season_id
+    );
+  END IF;
+
+  INSERT INTO public.orders (
+    user_id, market_id, outcome, side, quantity, total_cost, avg_price, season_id
+  )
+  VALUES (
+    p_user_id, p_market_id, v_outcome, 'BUY', p_quantity, v_total_cost, v_avg_price, v_market.season_id
+  )
+  RETURNING id INTO v_order_id;
+
+  INSERT INTO public.transactions (
+    user_id, type, amount, balance_after, reference_id, description, season_id
+  )
+  VALUES (
+    p_user_id, 'BUY', -v_total_cost, v_new_balance, v_order_id, '매수 주문 체결', v_market.season_id
+  );
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'order_id', v_order_id,
+    'quantity', p_quantity,
+    'total_cost', v_total_cost,
+    'avg_price', v_avg_price,
+    'new_balance', v_new_balance
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- C2. execute_sell_order: 시즌 인지 매도 (30분 쿨다운 보존)
+CREATE OR REPLACE FUNCTION public.execute_sell_order(
+  p_user_id UUID,
+  p_market_id INTEGER,
+  p_outcome TEXT,
+  p_quantity NUMERIC
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_outcome TEXT;
+  v_market public.markets%ROWTYPE;
+  v_active_season_id INTEGER;
+  v_wallet public.wallets%ROWTYPE;
+  v_position public.positions%ROWTYPE;
+  v_new_q_home NUMERIC;
+  v_new_q_away NUMERIC;
+  v_new_q_draw NUMERIC;
+  v_cost_before NUMERIC;
+  v_cost_after NUMERIC;
+  v_total_refund NUMERIC;
+  v_avg_price NUMERIC;
+  v_new_balance NUMERIC;
+  v_new_position_qty NUMERIC;
+  v_order_id INTEGER;
+BEGIN
+  -- 폐장 시간 체크 (KST 01:00 ~ 09:00)
+  IF EXTRACT(HOUR FROM (NOW() AT TIME ZONE 'Asia/Seoul')) >= 1
+     AND EXTRACT(HOUR FROM (NOW() AT TIME ZONE 'Asia/Seoul')) < 9 THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', '폐장 시간입니다 (새벽 1시 ~ 오전 9시). 오전 9시 이후에 거래해주세요.'
+    );
+  END IF;
+
+  v_outcome := UPPER(BTRIM(COALESCE(p_outcome, '')));
+
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_quantity IS NULL OR p_quantity <= 0 THEN
+    RAISE EXCEPTION '매도 수량은 0보다 커야 합니다';
+  END IF;
+
+  IF v_outcome NOT IN ('HOME', 'AWAY', 'DRAW') THEN
+    RAISE EXCEPTION 'outcome은 HOME, AWAY, DRAW 중 하나여야 합니다';
+  END IF;
+
+  SELECT *
+  INTO v_market
+  FROM public.markets
+  WHERE id = p_market_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  IF v_market.status <> 'OPEN' THEN
+    RAISE EXCEPTION '현재 거래할 수 없는 마켓입니다';
+  END IF;
+
+  -- 시즌 검증
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  IF v_market.season_id <> v_active_season_id THEN
+    RAISE EXCEPTION '이 시즌은 더 이상 거래할 수 없습니다';
+  END IF;
+
+  SELECT *
+  INTO v_position
+  FROM public.positions
+  WHERE user_id = p_user_id
+    AND market_id = p_market_id
+    AND outcome = v_outcome
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_position.quantity < p_quantity THEN
+    RAISE EXCEPTION '보유 수량이 부족합니다';
+  END IF;
+
+  -- 30분 매도 쿨다운 (보존)
+  IF v_position.purchased_at IS NOT NULL AND
+     (NOW() AT TIME ZONE 'Asia/Seoul') - (v_position.purchased_at AT TIME ZONE 'Asia/Seoul') < INTERVAL '30 minutes' THEN
+    RAISE EXCEPTION '매수 후 30분이 지나야 매도할 수 있습니다';
+  END IF;
+
+  v_new_q_home := v_market.q_home;
+  v_new_q_away := v_market.q_away;
+  v_new_q_draw := v_market.q_draw;
+
+  CASE v_outcome
+    WHEN 'HOME' THEN v_new_q_home := v_new_q_home - p_quantity;
+    WHEN 'AWAY' THEN v_new_q_away := v_new_q_away - p_quantity;
+    WHEN 'DRAW' THEN v_new_q_draw := v_new_q_draw - p_quantity;
+  END CASE;
+
+  v_cost_before := public.lmsr_cost(v_market.q_home, v_market.q_away, v_market.q_draw, v_market.b);
+  v_cost_after := public.lmsr_cost(v_new_q_home, v_new_q_away, v_new_q_draw, v_market.b);
+  v_total_refund := 100 * (v_cost_before - v_cost_after);
+
+  IF v_total_refund <= 0 THEN
+    RAISE EXCEPTION '환급금 계산에 실패했습니다';
+  END IF;
+
+  v_avg_price := v_total_refund / p_quantity;
+
+  -- 시즌 인지 지갑 잠금
+  SELECT *
+  INTO v_wallet
+  FROM public.wallets
+  WHERE user_id = p_user_id
+    AND season_id = v_market.season_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '지갑 정보를 찾을 수 없습니다';
+  END IF;
+
+  v_new_balance := v_wallet.balance + v_total_refund;
+
+  UPDATE public.markets
+  SET
+    q_home = v_new_q_home,
+    q_away = v_new_q_away,
+    q_draw = v_new_q_draw,
+    updated_at = NOW()
+  WHERE id = v_market.id;
+
+  v_new_position_qty := v_position.quantity - p_quantity;
+
+  UPDATE public.positions
+  SET
+    quantity = v_new_position_qty,
+    avg_entry_price = CASE
+      WHEN v_new_position_qty = 0 THEN 0
+      ELSE avg_entry_price
+    END,
+    updated_at = NOW()
+  WHERE id = v_position.id;
+
+  UPDATE public.wallets
+  SET
+    balance = v_new_balance,
+    updated_at = NOW()
+  WHERE id = v_wallet.id;
+
+  INSERT INTO public.orders (
+    user_id, market_id, outcome, side, quantity, total_cost, avg_price, season_id
+  )
+  VALUES (
+    p_user_id, p_market_id, v_outcome, 'SELL', p_quantity, v_total_refund, v_avg_price, v_market.season_id
+  )
+  RETURNING id INTO v_order_id;
+
+  INSERT INTO public.transactions (
+    user_id, type, amount, balance_after, reference_id, description, season_id
+  )
+  VALUES (
+    p_user_id, 'SELL', v_total_refund, v_new_balance, v_order_id, '매도 주문 체결', v_market.season_id
+  );
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'order_id', v_order_id,
+    'quantity', p_quantity,
+    'total_refund', v_total_refund,
+    'avg_price', v_avg_price,
+    'new_balance', v_new_balance
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- C3. execute_buy_by_amount: 시즌 인지 금액 기반 매수
+CREATE OR REPLACE FUNCTION public.execute_buy_by_amount(
+  p_user_id UUID,
+  p_market_id INTEGER,
+  p_outcome TEXT,
+  p_amount NUMERIC
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_outcome TEXT;
+  v_market public.markets%ROWTYPE;
+  v_active_season_id INTEGER;
+  v_wallet public.wallets%ROWTYPE;
+  v_cost_before NUMERIC;
+  v_estimated_cost NUMERIC;
+  v_low NUMERIC := 0;
+  v_high NUMERIC := 1;
+  v_mid NUMERIC;
+  v_quantity NUMERIC;
+  v_new_q_home NUMERIC;
+  v_new_q_away NUMERIC;
+  v_new_q_draw NUMERIC;
+  v_result JSONB;
+  v_i INTEGER;
+BEGIN
+  -- 폐장 시간 체크 (KST 01:00 ~ 09:00)
+  IF EXTRACT(HOUR FROM (NOW() AT TIME ZONE 'Asia/Seoul')) >= 1
+     AND EXTRACT(HOUR FROM (NOW() AT TIME ZONE 'Asia/Seoul')) < 9 THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', '폐장 시간입니다 (새벽 1시 ~ 오전 9시). 오전 9시 이후에 거래해주세요.'
+    );
+  END IF;
+
+  v_outcome := UPPER(BTRIM(COALESCE(p_outcome, '')));
+
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION '매수 금액은 0보다 커야 합니다';
+  END IF;
+
+  IF v_outcome NOT IN ('HOME', 'AWAY', 'DRAW') THEN
+    RAISE EXCEPTION 'outcome은 HOME, AWAY, DRAW 중 하나여야 합니다';
+  END IF;
+
+  SELECT *
+  INTO v_market
+  FROM public.markets
+  WHERE id = p_market_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  IF v_market.status <> 'OPEN' THEN
+    RAISE EXCEPTION '현재 거래할 수 없는 마켓입니다';
+  END IF;
+
+  -- 시즌 검증 (execute_buy_order 내부에서도 한 번 더 검사되지만 명확한 에러를 위해 선검사)
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  IF v_market.season_id <> v_active_season_id THEN
+    RAISE EXCEPTION '이 시즌은 더 이상 거래할 수 없습니다';
+  END IF;
+
+  -- 시즌 인지 지갑 잠금
+  SELECT *
+  INTO v_wallet
+  FROM public.wallets
+  WHERE user_id = p_user_id
+    AND season_id = v_market.season_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '지갑 정보를 찾을 수 없습니다';
+  END IF;
+
+  IF v_wallet.balance < p_amount THEN
+    RAISE EXCEPTION '잔고가 부족합니다';
+  END IF;
+
+  v_cost_before := public.lmsr_cost(v_market.q_home, v_market.q_away, v_market.q_draw, v_market.b);
+
+  -- 이진탐색: high 부터 비용이 p_amount 를 넘을 때까지 2배씩 확장
+  FOR v_i IN 1..60 LOOP
+    v_new_q_home := v_market.q_home;
+    v_new_q_away := v_market.q_away;
+    v_new_q_draw := v_market.q_draw;
+
+    CASE v_outcome
+      WHEN 'HOME' THEN v_new_q_home := v_new_q_home + v_high;
+      WHEN 'AWAY' THEN v_new_q_away := v_new_q_away + v_high;
+      WHEN 'DRAW' THEN v_new_q_draw := v_new_q_draw + v_high;
+    END CASE;
+
+    v_estimated_cost := 100 * (
+      public.lmsr_cost(v_new_q_home, v_new_q_away, v_new_q_draw, v_market.b) - v_cost_before
+    );
+
+    EXIT WHEN v_estimated_cost >= p_amount;
+    v_high := v_high * 2;
+  END LOOP;
+
+  -- 이진탐색: low ~ high 사이에서 80회 반복으로 정밀화
+  FOR v_i IN 1..80 LOOP
+    v_mid := (v_low + v_high) / 2;
+
+    v_new_q_home := v_market.q_home;
+    v_new_q_away := v_market.q_away;
+    v_new_q_draw := v_market.q_draw;
+
+    CASE v_outcome
+      WHEN 'HOME' THEN v_new_q_home := v_new_q_home + v_mid;
+      WHEN 'AWAY' THEN v_new_q_away := v_new_q_away + v_mid;
+      WHEN 'DRAW' THEN v_new_q_draw := v_new_q_draw + v_mid;
+    END CASE;
+
+    v_estimated_cost := 100 * (
+      public.lmsr_cost(v_new_q_home, v_new_q_away, v_new_q_draw, v_market.b) - v_cost_before
+    );
+
+    IF v_estimated_cost <= p_amount THEN
+      v_low := v_mid;
+    ELSE
+      v_high := v_mid;
+    END IF;
+  END LOOP;
+
+  v_quantity := TRUNC(v_low, 8);
+
+  IF v_quantity <= 0 THEN
+    RAISE EXCEPTION '입력한 금액으로는 매수할 수 없습니다';
+  END IF;
+
+  SELECT public.execute_buy_order(p_user_id, p_market_id, v_outcome, v_quantity)
+  INTO v_result;
+
+  RETURN v_result;
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- C4. settle_market: 시즌 인지 정산
+CREATE OR REPLACE FUNCTION public.settle_market(
+  p_market_id INTEGER,
+  p_result TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_result TEXT;
+  v_market public.markets%ROWTYPE;
+  v_active_season_id INTEGER;
+  v_user_payout RECORD;
+  v_wallet public.wallets%ROWTYPE;
+  v_new_balance NUMERIC;
+  v_total_users_settled INTEGER := 0;
+  v_total_coins_distributed NUMERIC := 0;
+BEGIN
+  v_result := UPPER(BTRIM(COALESCE(p_result, '')));
+
+  IF v_result NOT IN ('HOME', 'AWAY', 'DRAW') THEN
+    RAISE EXCEPTION '정산 결과는 HOME, AWAY, DRAW 중 하나여야 합니다';
+  END IF;
+
+  SELECT *
+  INTO v_market
+  FROM public.markets
+  WHERE id = p_market_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  IF v_market.status = 'SETTLED' THEN
+    RAISE EXCEPTION '이미 정산된 마켓입니다';
+  END IF;
+
+  IF v_market.status = 'CANCELED' THEN
+    RAISE EXCEPTION '취소된 마켓은 정산할 수 없습니다';
+  END IF;
+
+  -- 시즌 hard-block: 마켓 시즌이 현재 ACTIVE 시즌이 아니면 정산 차단
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  IF v_market.season_id <> v_active_season_id THEN
+    RAISE EXCEPTION '시즌이 활성 상태가 아니어서 정산할 수 없습니다 (마켓 시즌: %, 현재 활성 시즌: %)',
+      v_market.season_id, v_active_season_id;
+  END IF;
+
+  UPDATE public.markets
+  SET
+    status = 'SETTLED',
+    result = v_result,
+    updated_at = NOW()
+  WHERE id = p_market_id;
+
+  FOR v_user_payout IN
+    SELECT
+      p.user_id,
+      COALESCE(SUM(
+        CASE
+          WHEN p.outcome = v_result THEN p.quantity * 100
+          ELSE 0
+        END
+      ), 0) AS payout
+    FROM public.positions p
+    WHERE p.market_id = p_market_id
+      AND p.quantity > 0
+    GROUP BY p.user_id
+  LOOP
+    -- 시즌 인지 지갑 잠금 (마켓 시즌과 동일한 시즌의 지갑만 사용)
+    SELECT *
+    INTO v_wallet
+    FROM public.wallets
+    WHERE user_id = v_user_payout.user_id
+      AND season_id = v_market.season_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      -- 거래가 발생했다면 지갑은 반드시 있어야 함. 방어적으로 RAISE.
+      RAISE EXCEPTION '정산 대상 사용자의 지갑을 찾을 수 없습니다 (user_id: %, season_id: %)',
+        v_user_payout.user_id, v_market.season_id;
+    END IF;
+
+    v_new_balance := v_wallet.balance + v_user_payout.payout;
+
+    UPDATE public.wallets
+    SET
+      balance = v_new_balance,
+      updated_at = NOW()
+    WHERE id = v_wallet.id;
+
+    INSERT INTO public.transactions (
+      user_id, type, amount, balance_after, reference_id, description, season_id
+    )
+    VALUES (
+      v_user_payout.user_id,
+      'SETTLEMENT',
+      v_user_payout.payout,
+      v_new_balance,
+      p_market_id,
+      '마켓 정산 - ' || v_result,
+      v_market.season_id
+    );
+
+    v_total_users_settled := v_total_users_settled + 1;
+    v_total_coins_distributed := v_total_coins_distributed + v_user_payout.payout;
+  END LOOP;
+
+  -- 정산된 마켓의 포지션을 모두 0 으로 클로즈
+  UPDATE public.positions
+  SET
+    quantity = 0,
+    avg_entry_price = 0,
+    updated_at = NOW()
+  WHERE market_id = p_market_id;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'total_users_settled', v_total_users_settled,
+    'total_coins_distributed', v_total_coins_distributed
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- C5. cancel_market: 시즌 인지 취소 + 원가 환급
+CREATE OR REPLACE FUNCTION public.cancel_market(
+  p_market_id INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_market public.markets%ROWTYPE;
+  v_active_season_id INTEGER;
+  v_refund_row RECORD;
+  v_wallet public.wallets%ROWTYPE;
+  v_new_balance NUMERIC;
+  v_total_users_refunded INTEGER := 0;
+  v_total_refunded NUMERIC := 0;
+BEGIN
+  IF p_market_id IS NULL OR p_market_id <= 0 THEN
+    RAISE EXCEPTION '마켓 정보가 올바르지 않습니다';
+  END IF;
+
+  SELECT *
+  INTO v_market
+  FROM public.markets
+  WHERE id = p_market_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  IF v_market.status = 'SETTLED' THEN
+    RAISE EXCEPTION '이미 정산된 마켓은 취소할 수 없습니다';
+  END IF;
+
+  IF v_market.status = 'CANCELED' THEN
+    RAISE EXCEPTION '이미 취소된 마켓입니다';
+  END IF;
+
+  -- 시즌 검증
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  IF v_market.season_id <> v_active_season_id THEN
+    RAISE EXCEPTION '시즌이 활성 상태가 아니어서 정산할 수 없습니다 (마켓 시즌: %, 현재 활성 시즌: %)',
+      v_market.season_id, v_active_season_id;
+  END IF;
+
+  UPDATE public.markets
+  SET
+    status = 'CANCELED',
+    result = NULL,
+    updated_at = NOW()
+  WHERE id = p_market_id;
+
+  FOR v_refund_row IN
+    SELECT
+      p.user_id,
+      COALESCE(SUM(p.quantity * p.avg_entry_price), 0) AS refund_amount
+    FROM public.positions p
+    WHERE p.market_id = p_market_id
+      AND p.quantity > 0
+    GROUP BY p.user_id
+    HAVING COALESCE(SUM(p.quantity * p.avg_entry_price), 0) > 0
+  LOOP
+    -- 시즌 인지 지갑 잠금
+    SELECT *
+    INTO v_wallet
+    FROM public.wallets
+    WHERE user_id = v_refund_row.user_id
+      AND season_id = v_market.season_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION '환급 대상 사용자의 지갑을 찾을 수 없습니다 (user_id: %, season_id: %)',
+        v_refund_row.user_id, v_market.season_id;
+    END IF;
+
+    v_new_balance := v_wallet.balance + v_refund_row.refund_amount;
+
+    UPDATE public.wallets
+    SET
+      balance = v_new_balance,
+      updated_at = NOW()
+    WHERE id = v_wallet.id;
+
+    INSERT INTO public.transactions (
+      user_id, type, amount, balance_after, reference_id, description, season_id
+    )
+    VALUES (
+      v_refund_row.user_id,
+      'SETTLEMENT',
+      v_refund_row.refund_amount,
+      v_new_balance,
+      p_market_id,
+      '마켓 취소 원가 환급',
+      v_market.season_id
+    );
+
+    v_total_users_refunded := v_total_users_refunded + 1;
+    v_total_refunded := v_total_refunded + v_refund_row.refund_amount;
+  END LOOP;
+
+  UPDATE public.positions
+  SET
+    quantity = 0,
+    avg_entry_price = 0,
+    updated_at = NOW()
+  WHERE market_id = p_market_id;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'market_id', p_market_id,
+    'status', 'CANCELED',
+    'total_users_refunded', v_total_users_refunded,
+    'total_refunded', v_total_refunded
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- C6. close_market: OPEN → CLOSED (시즌 검증만 추가)
+CREATE OR REPLACE FUNCTION public.close_market(
+  p_market_id INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_market public.markets%ROWTYPE;
+  v_active_season_id INTEGER;
+BEGIN
+  IF p_market_id IS NULL OR p_market_id <= 0 THEN
+    RAISE EXCEPTION '마켓 정보가 올바르지 않습니다';
+  END IF;
+
+  SELECT *
+  INTO v_market
+  FROM public.markets
+  WHERE id = p_market_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  IF v_market.status = 'SETTLED' THEN
+    RAISE EXCEPTION '이미 정산된 마켓은 종료할 수 없습니다';
+  END IF;
+
+  IF v_market.status = 'CANCELED' THEN
+    RAISE EXCEPTION '취소된 마켓은 종료할 수 없습니다';
+  END IF;
+
+  -- 시즌 검증 (방어적: 과거 시즌 마켓을 close 하지 않도록)
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  IF v_market.season_id <> v_active_season_id THEN
+    RAISE EXCEPTION '시즌이 활성 상태가 아니어서 정산할 수 없습니다 (마켓 시즌: %, 현재 활성 시즌: %)',
+      v_market.season_id, v_active_season_id;
+  END IF;
+
+  IF v_market.status <> 'CLOSED' THEN
+    UPDATE public.markets
+    SET
+      status = 'CLOSED',
+      updated_at = NOW()
+    WHERE id = p_market_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'market_id', p_market_id,
+    'status', 'CLOSED'
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- C7. create_market: 활성 시즌으로 마켓 생성
+CREATE OR REPLACE FUNCTION public.create_market(
+  p_game_id INTEGER,
+  p_initial_home NUMERIC DEFAULT 47.5,
+  p_initial_away NUMERIC DEFAULT 47.5,
+  p_initial_draw NUMERIC DEFAULT 5.0
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_active_season_id INTEGER;
+  v_b NUMERIC;
+  v_total_probability NUMERIC;
+  v_market_id INTEGER;
+BEGIN
+  IF p_game_id IS NULL THEN
+    RAISE EXCEPTION '경기 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_initial_home <= 0 OR p_initial_away <= 0 OR p_initial_draw <= 0 THEN
+    RAISE EXCEPTION '초기 확률은 모두 0보다 커야 합니다';
+  END IF;
+
+  v_total_probability := p_initial_home + p_initial_away + p_initial_draw;
+
+  IF ABS(v_total_probability - 100) > 0.000001 THEN
+    RAISE EXCEPTION '초기 확률의 합은 100이어야 합니다';
+  END IF;
+
+  SELECT id INTO v_active_season_id
+  FROM public.seasons
+  WHERE status = 'ACTIVE'
+  LIMIT 1;
+
+  IF v_active_season_id IS NULL THEN
+    RAISE EXCEPTION '활성 시즌이 없습니다';
+  END IF;
+
+  SELECT (value ->> 'value')::NUMERIC
+  INTO v_b
+  FROM public.settings
+  WHERE key = 'liquidity_b'
+  LIMIT 1;
+
+  IF v_b IS NULL OR v_b <= 0 THEN
+    RAISE EXCEPTION '유효한 유동성 파라미터(b)를 찾을 수 없습니다';
+  END IF;
+
+  INSERT INTO public.markets (
+    game_id, q_home, q_away, q_draw, b, status, result,
+    initial_home_price, initial_away_price, initial_draw_price,
+    season_id
+  )
+  VALUES (
+    p_game_id,
+    v_b * LN(p_initial_home),
+    v_b * LN(p_initial_away),
+    v_b * LN(p_initial_draw),
+    v_b,
+    'OPEN',
+    NULL,
+    p_initial_home,
+    p_initial_away,
+    p_initial_draw,
+    v_active_season_id
+  )
+  RETURNING id INTO v_market_id;
+
+  RETURN v_market_id;
+END;
+$$;
+
+
+-- ============================================================================
+-- SECTION D: 리더보드 / 히스토리 RPC 업데이트
+-- ============================================================================
+
+-- D1. get_leaderboard_balance: 시즌별 잔고 랭킹 (JSONB)
+DROP FUNCTION IF EXISTS public.get_leaderboard_balance();
+CREATE OR REPLACE FUNCTION public.get_leaderboard_balance(
+  p_season_id INTEGER DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_season_id INTEGER;
+  v_ranks JSONB;
+BEGIN
+  IF p_season_id IS NULL THEN
+    SELECT id INTO v_season_id
+    FROM public.seasons
+    WHERE status = 'ACTIVE'
+    LIMIT 1;
+
+    IF v_season_id IS NULL THEN
+      RAISE EXCEPTION '활성 시즌이 없습니다';
+    END IF;
+  ELSE
+    v_season_id := p_season_id;
+  END IF;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'rank', r.position_rank,
+        'user_id', r.user_id,
+        'username', r.username,
+        'balance', r.balance
+      )
+      ORDER BY r.position_rank, r.username, r.user_id
+    ),
+    '[]'::JSONB
+  )
+  INTO v_ranks
+  FROM (
+    SELECT
+      ROW_NUMBER() OVER (
+        ORDER BY
+          w.balance DESC,
+          u.username ASC,
+          u.id ASC
+      )::BIGINT AS position_rank,
+      u.id AS user_id,
+      u.username::TEXT AS username,
+      w.balance
+    FROM public.wallets w
+    JOIN public.users u ON u.id = w.user_id
+    WHERE w.season_id = v_season_id
+  ) r;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'season_id', v_season_id,
+    'ranks', v_ranks
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- D2. get_leaderboard_roi: 시즌별 ROI 랭킹 (JSONB)
+DROP FUNCTION IF EXISTS public.get_leaderboard_roi();
+CREATE OR REPLACE FUNCTION public.get_leaderboard_roi(
+  p_season_id INTEGER DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_season_id INTEGER;
+  v_ranks JSONB;
+BEGIN
+  IF p_season_id IS NULL THEN
+    SELECT id INTO v_season_id
+    FROM public.seasons
+    WHERE status = 'ACTIVE'
+    LIMIT 1;
+
+    IF v_season_id IS NULL THEN
+      RAISE EXCEPTION '활성 시즌이 없습니다';
+    END IF;
+  ELSE
+    v_season_id := p_season_id;
+  END IF;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'rank', r.position_rank,
+        'user_id', r.user_id,
+        'username', r.username,
+        'roi_percent', r.roi_percent,
+        'current_balance', r.current_balance,
+        'total_granted', r.total_granted
+      )
+      ORDER BY r.position_rank, r.username, r.user_id
+    ),
+    '[]'::JSONB
+  )
+  INTO v_ranks
+  FROM (
+    SELECT
+      ROW_NUMBER() OVER (
+        ORDER BY
+          CASE WHEN g.total_granted > 0 THEN
+            ((COALESCE(w.balance, 0) - g.total_granted) / g.total_granted) * 100
+          ELSE 0
+          END DESC,
+          COALESCE(w.balance, 0) DESC,
+          u.username ASC,
+          u.id ASC
+      )::BIGINT AS position_rank,
+      u.id AS user_id,
+      u.username::TEXT AS username,
+      CASE WHEN g.total_granted > 0 THEN
+        ((COALESCE(w.balance, 0) - g.total_granted) / g.total_granted) * 100
+      ELSE 0
+      END AS roi_percent,
+      COALESCE(w.balance, 0) AS current_balance,
+      g.total_granted
+    FROM public.users u
+    LEFT JOIN public.wallets w
+      ON w.user_id = u.id AND w.season_id = v_season_id
+    LEFT JOIN LATERAL (
+      SELECT COALESCE(SUM(t.amount), 0) AS total_granted
+      FROM public.transactions t
+      WHERE t.user_id = u.id
+        AND t.season_id = v_season_id
+        AND t.type IN ('SEASON_GRANT', 'WEEKLY_GRANT', 'ADMIN_GRANT')
+    ) g ON TRUE
+    -- 해당 시즌에 grant 가 한 푼도 없는 사용자는 ROI 계산이 의미 없으므로 제외
+    WHERE g.total_granted > 0
+  ) r;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'season_id', v_season_id,
+    'ranks', v_ranks
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', SQLERRM
+    );
+END;
+$$;
+
+
+-- D3. get_user_open_positions: 시즌별 진행 포지션 조회
+DROP FUNCTION IF EXISTS public.get_user_open_positions(UUID);
+DROP FUNCTION IF EXISTS public.get_user_open_positions(UUID, INTEGER);
+CREATE OR REPLACE FUNCTION public.get_user_open_positions(
+  p_user_id UUID,
+  p_season_id INTEGER DEFAULT NULL
+)
+RETURNS TABLE(
+  market_id INTEGER,
+  outcome TEXT,
+  quantity NUMERIC,
+  avg_entry_price NUMERIC,
+  season_id INTEGER,
+  season_name TEXT,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_season_id INTEGER;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_season_id IS NULL THEN
+    SELECT id INTO v_season_id
+    FROM public.seasons
+    WHERE status = 'ACTIVE'
+    LIMIT 1;
+
+    IF v_season_id IS NULL THEN
+      RAISE EXCEPTION '활성 시즌이 없습니다';
+    END IF;
+  ELSE
+    v_season_id := p_season_id;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.market_id,
+    p.outcome::TEXT,
+    p.quantity,
+    p.avg_entry_price,
+    p.season_id,
+    s.name::TEXT AS season_name,
+    p.updated_at
+  FROM public.positions p
+  JOIN public.seasons s ON s.id = p.season_id
+  WHERE p.user_id = p_user_id
+    AND p.season_id = v_season_id
+    AND p.quantity > 0
+  ORDER BY p.updated_at DESC, p.market_id DESC;
+END;
+$$;
+
+
+-- D4. get_user_orders_by_date: 시즌 옵션 + 시즌명 포함
+DROP FUNCTION IF EXISTS public.get_user_orders_by_date(UUID, TIMESTAMPTZ, TIMESTAMPTZ);
+DROP FUNCTION IF EXISTS public.get_user_orders_by_date(UUID, TIMESTAMPTZ, TIMESTAMPTZ, INTEGER);
+CREATE OR REPLACE FUNCTION public.get_user_orders_by_date(
+  p_user_id UUID,
+  p_start_at TIMESTAMPTZ,
+  p_end_at TIMESTAMPTZ,
+  p_season_id INTEGER DEFAULT NULL
+)
+RETURNS TABLE(
+  order_id INTEGER,
+  market_id INTEGER,
+  outcome TEXT,
+  side TEXT,
+  quantity NUMERIC,
+  total_cost NUMERIC,
+  avg_price NUMERIC,
+  season_id INTEGER,
+  season_name TEXT,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  IF p_start_at IS NULL OR p_end_at IS NULL OR p_start_at >= p_end_at THEN
+    RAISE EXCEPTION '조회 기간이 올바르지 않습니다';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    o.id,
+    o.market_id,
+    o.outcome::TEXT,
+    o.side::TEXT,
+    o.quantity,
+    o.total_cost,
+    o.avg_price,
+    o.season_id,
+    s.name::TEXT AS season_name,
+    o.created_at
+  FROM public.orders o
+  JOIN public.seasons s ON s.id = o.season_id
+  WHERE o.user_id = p_user_id
+    AND o.created_at >= p_start_at
+    AND o.created_at < p_end_at
+    AND (p_season_id IS NULL OR o.season_id = p_season_id)
+  ORDER BY o.created_at DESC, o.id DESC;
+END;
+$$;
+
+
+-- D5. get_user_settlement_history: 시즌 옵션 + 시즌명 포함
+DROP FUNCTION IF EXISTS public.get_user_settlement_history(UUID);
+DROP FUNCTION IF EXISTS public.get_user_settlement_history(UUID, INTEGER);
+CREATE OR REPLACE FUNCTION public.get_user_settlement_history(
+  p_user_id UUID,
+  p_season_id INTEGER DEFAULT NULL
+)
+RETURNS TABLE(
+  market_id INTEGER,
+  settled_at TIMESTAMPTZ,
+  settlement_amount NUMERIC,
+  net_invested NUMERIC,
+  final_pnl NUMERIC,
+  home_quantity NUMERIC,
+  away_quantity NUMERIC,
+  draw_quantity NUMERIC,
+  season_id INTEGER,
+  season_name TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION '사용자 정보가 올바르지 않습니다';
+  END IF;
+
+  RETURN QUERY
+  WITH settlement_transactions AS (
+    SELECT
+      t.reference_id AS market_id,
+      MAX(t.created_at) AS settled_at,
+      COALESCE(SUM(t.amount), 0) AS settlement_amount,
+      MAX(t.season_id) AS season_id
+    FROM public.transactions t
+    WHERE t.user_id = p_user_id
+      AND t.type = 'SETTLEMENT'
+      AND t.reference_id IS NOT NULL
+      AND (p_season_id IS NULL OR t.season_id = p_season_id)
+    GROUP BY t.reference_id
+  ),
+  order_aggregates AS (
+    SELECT
+      o.market_id,
+      COALESCE(
+        SUM(
+          CASE
+            WHEN o.side = 'BUY' THEN o.total_cost
+            WHEN o.side = 'SELL' THEN -o.total_cost
+            ELSE 0
+          END
+        ),
+        0
+      ) AS net_invested,
+      COALESCE(
+        SUM(
+          CASE
+            WHEN o.outcome = 'HOME' AND o.side = 'BUY' THEN o.quantity
+            WHEN o.outcome = 'HOME' AND o.side = 'SELL' THEN -o.quantity
+            ELSE 0
+          END
+        ),
+        0
+      ) AS home_quantity,
+      COALESCE(
+        SUM(
+          CASE
+            WHEN o.outcome = 'AWAY' AND o.side = 'BUY' THEN o.quantity
+            WHEN o.outcome = 'AWAY' AND o.side = 'SELL' THEN -o.quantity
+            ELSE 0
+          END
+        ),
+        0
+      ) AS away_quantity,
+      COALESCE(
+        SUM(
+          CASE
+            WHEN o.outcome = 'DRAW' AND o.side = 'BUY' THEN o.quantity
+            WHEN o.outcome = 'DRAW' AND o.side = 'SELL' THEN -o.quantity
+            ELSE 0
+          END
+        ),
+        0
+      ) AS draw_quantity
+    FROM public.orders o
+    WHERE o.user_id = p_user_id
+      AND (p_season_id IS NULL OR o.season_id = p_season_id)
+    GROUP BY o.market_id
+  )
+  SELECT
+    st.market_id,
+    st.settled_at,
+    st.settlement_amount,
+    COALESCE(a.net_invested, 0) AS net_invested,
+    st.settlement_amount - COALESCE(a.net_invested, 0) AS final_pnl,
+    COALESCE(a.home_quantity, 0) AS home_quantity,
+    COALESCE(a.away_quantity, 0) AS away_quantity,
+    COALESCE(a.draw_quantity, 0) AS draw_quantity,
+    st.season_id,
+    s.name::TEXT AS season_name
+  FROM settlement_transactions st
+  LEFT JOIN order_aggregates a
+    ON a.market_id = st.market_id
+  LEFT JOIN public.seasons s
+    ON s.id = st.season_id
+  ORDER BY st.settled_at DESC, st.market_id DESC;
+END;
+$$;
+
+
+-- D6. get_market_detail: 마켓 + 시즌 + 경기 + 가격 통합 상세 조회
+CREATE OR REPLACE FUNCTION public.get_market_detail(
+  p_market_id INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_detail RECORD;
+  v_prices JSONB;
+BEGIN
+  SELECT
+    m.id AS market_id,
+    m.game_id,
+    m.q_home,
+    m.q_away,
+    m.q_draw,
+    m.b,
+    m.status,
+    m.result,
+    m.initial_home_price,
+    m.initial_away_price,
+    m.initial_draw_price,
+    m.created_at AS market_created_at,
+    m.updated_at AS market_updated_at,
+    m.season_id,
+    s.name AS season_name,
+    g.id AS game_id_value,
+    g.game_date,
+    g.game_time,
+    g.game_status,
+    g.home_pitcher,
+    g.away_pitcher,
+    g.home_score,
+    g.away_score,
+    ht.id AS home_team_id,
+    ht.name AS home_team_name,
+    ht.short_name AS home_team_short_name,
+    at.id AS away_team_id,
+    at.name AS away_team_name,
+    at.short_name AS away_team_short_name
+  INTO v_detail
+  FROM public.markets m
+  JOIN public.games g ON g.id = m.game_id
+  JOIN public.teams ht ON ht.id = g.home_team_id
+  JOIN public.teams at ON at.id = g.away_team_id
+  LEFT JOIN public.seasons s ON s.id = m.season_id
+  WHERE m.id = p_market_id
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '마켓을 찾을 수 없습니다';
+  END IF;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'outcome', p.outcome,
+        'price', p.price
+      )
+      ORDER BY CASE p.outcome
+        WHEN 'HOME' THEN 1
+        WHEN 'AWAY' THEN 2
+        ELSE 3
+      END
+    ),
+    '[]'::JSONB
+  )
+  INTO v_prices
+  FROM public.lmsr_prices(p_market_id) p;
+
+  RETURN jsonb_build_object(
+    'market', jsonb_build_object(
+      'id', v_detail.market_id,
+      'game_id', v_detail.game_id,
+      'q_home', v_detail.q_home,
+      'q_away', v_detail.q_away,
+      'q_draw', v_detail.q_draw,
+      'b', v_detail.b,
+      'status', v_detail.status,
+      'result', v_detail.result,
+      'initial_home_price', v_detail.initial_home_price,
+      'initial_away_price', v_detail.initial_away_price,
+      'initial_draw_price', v_detail.initial_draw_price,
+      'created_at', v_detail.market_created_at,
+      'updated_at', v_detail.market_updated_at,
+      'season_id', v_detail.season_id,
+      'season_name', v_detail.season_name
+    ),
+    'prices', v_prices,
+    'game', jsonb_build_object(
+      'id', v_detail.game_id_value,
+      'game_date', v_detail.game_date,
+      'game_time', v_detail.game_time,
+      'game_status', v_detail.game_status,
+      'home_pitcher', v_detail.home_pitcher,
+      'away_pitcher', v_detail.away_pitcher,
+      'home_score', v_detail.home_score,
+      'away_score', v_detail.away_score,
+      'home_team', jsonb_build_object(
+        'id', v_detail.home_team_id,
+        'name', v_detail.home_team_name,
+        'short_name', v_detail.home_team_short_name
+      ),
+      'away_team', jsonb_build_object(
+        'id', v_detail.away_team_id,
+        'name', v_detail.away_team_name,
+        'short_name', v_detail.away_team_short_name
+      )
+    )
+  );
+END;
+$$;
+
+
+-- ============================================================================
+-- SECTION E: GRANT + pg_cron 검증
+-- ============================================================================
+
+-- E1. anon/authenticated 실행 권한 부여
+GRANT EXECUTE ON FUNCTION public.get_active_season() TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.list_seasons() TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_season(TEXT, DATE, DATE) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.activate_season(INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.end_season(INTEGER) TO anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.login(BIGINT, TEXT) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_wallet_balance(UUID, INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.distribute_weekly_coins(NUMERIC) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_grant_coins(UUID, NUMERIC) TO anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.execute_buy_order(UUID, INTEGER, TEXT, NUMERIC) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.execute_sell_order(UUID, INTEGER, TEXT, NUMERIC) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.execute_buy_by_amount(UUID, INTEGER, TEXT, NUMERIC) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.settle_market(INTEGER, TEXT) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_market(INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.close_market(INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_market(INTEGER, NUMERIC, NUMERIC, NUMERIC) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_market_detail(INTEGER) TO anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.get_leaderboard_balance(INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_leaderboard_roi(INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_open_positions(UUID, INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_orders_by_date(UUID, TIMESTAMPTZ, TIMESTAMPTZ, INTEGER) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_settlement_history(UUID, INTEGER) TO anon, authenticated;
+
+
+-- E2. pg_cron weekly_coin_distribution 작업 상태 진단 (NOTICE only, non-fatal)
+DO $$
+DECLARE
+  v_has_pg_cron BOOLEAN := FALSE;
+  v_job_command TEXT;
+BEGIN
+  SELECT EXISTS(
+    SELECT 1 FROM pg_extension WHERE extname = 'pg_cron'
+  )
+  INTO v_has_pg_cron;
+
+  IF NOT v_has_pg_cron THEN
+    RAISE NOTICE 'pg_cron 확장이 비활성화되어 있어 weekly_coin_distribution 작업 검증을 건너뜁니다 (staging 환경일 수 있음).';
+    RETURN;
+  END IF;
+
+  BEGIN
+    EXECUTE
+      'SELECT command FROM cron.job WHERE jobname = ''weekly_coin_distribution'' LIMIT 1'
+    INTO v_job_command;
+  EXCEPTION
+    WHEN OTHERS THEN
+      RAISE NOTICE 'cron.job 조회 권한이 없어 weekly_coin_distribution 작업 검증을 건너뜁니다: %', SQLERRM;
+      RETURN;
+  END;
+
+  IF v_job_command IS NULL THEN
+    RAISE NOTICE 'weekly_coin_distribution 작업이 cron.job 에 등록되어 있지 않습니다. 필요 시 수동 등록이 필요합니다.';
+  ELSE
+    RAISE NOTICE 'weekly_coin_distribution 작업이 존재합니다 (command: %). distribute_weekly_coins 시그니처가 유지되어 추가 작업 불필요.', v_job_command;
+  END IF;
+END $$;
+
+
+DO $$
+BEGIN
+  RAISE NOTICE 'US-012 Wave 2 RPC migration applied: 22 season-aware functions';
+END $$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -14,7 +14,6 @@ DELETE FROM public.orders;
 DELETE FROM public.positions;
 DELETE FROM public.wallets;
 DELETE FROM public.markets;
-DELETE FROM public.predictions;
 DELETE FROM public.games;
 DELETE FROM public.users;
 
@@ -68,18 +67,18 @@ SELECT create_market(905, 47.5, 47.5, 5.0);  -- SSG vs 한화 (CANCELED)
 UPDATE public.markets SET status = 'CLOSED' WHERE game_id = 904;
 UPDATE public.markets SET status = 'CANCELED' WHERE game_id = 905;
 
--- 6) 지갑 생성 + 초기 코인 지급 (각 5000코인)
-INSERT INTO public.wallets (id, user_id, balance, created_at, updated_at)
+-- 6) 지갑 생성 + 초기 코인 지급 (각 5000코인) - active 시즌(Season 1) 기준
+INSERT INTO public.wallets (id, user_id, season_id, balance, created_at, updated_at)
 VALUES
-  (gen_random_uuid(), 'a1111111-1111-1111-1111-111111111111', 5000, NOW(), NOW()),
-  (gen_random_uuid(), 'a2222222-2222-2222-2222-222222222222', 5000, NOW(), NOW()),
-  (gen_random_uuid(), 'a3333333-3333-3333-3333-333333333333', 5000, NOW(), NOW());
+  (gen_random_uuid(), 'a1111111-1111-1111-1111-111111111111', 1, 5000, NOW(), NOW()),
+  (gen_random_uuid(), 'a2222222-2222-2222-2222-222222222222', 1, 5000, NOW(), NOW()),
+  (gen_random_uuid(), 'a3333333-3333-3333-3333-333333333333', 1, 5000, NOW(), NOW());
 
-INSERT INTO public.transactions (user_id, type, amount, balance_after, description, created_at)
+INSERT INTO public.transactions (user_id, season_id, type, amount, balance_after, description, created_at)
 VALUES
-  ('a1111111-1111-1111-1111-111111111111', 'WEEKLY_GRANT', 5000, 5000, '초기 코인 지급', NOW()),
-  ('a2222222-2222-2222-2222-222222222222', 'WEEKLY_GRANT', 5000, 5000, '초기 코인 지급', NOW()),
-  ('a3333333-3333-3333-3333-333333333333', 'WEEKLY_GRANT', 5000, 5000, '초기 코인 지급', NOW());
+  ('a1111111-1111-1111-1111-111111111111', 1, 'WEEKLY_GRANT', 5000, 5000, '초기 코인 지급', NOW()),
+  ('a2222222-2222-2222-2222-222222222222', 1, 'WEEKLY_GRANT', 5000, 5000, '초기 코인 지급', NOW()),
+  ('a3333333-3333-3333-3333-333333333333', 1, 'WEEKLY_GRANT', 5000, 5000, '초기 코인 지급', NOW());
 
 -- 7) 테스트 거래: 김테스트가 KIA vs 삼성에서 HOME 10주 매수
 SELECT execute_buy_order(


### PR DESCRIPTION
## Summary

시즌 단위로 코인이 격리되는 시즌 시스템 도입. 각 시즌은 독립된 잔고/거래/포지션을 갖고, 시즌 전환 시 이전 시즌은 ARCHIVED 상태로 잠겨 read-only가 된다.

- **Season 0** (id=0, ARCHIVED): 2026-03-28 KST 이전의 레거시 데이터 버킷
- **Season 1** (id=1, ACTIVE): 현재 활성 시즌 (3/28~)
- **Season 2** (id=2, DRAFT, 5/19~6/21): 관리자가 어드민 대시보드에서 수동 활성화 대기 중

## 🚨 배포 순서 (중요)

**Supabase 마이그레이션 → main merge → Vercel 자동 배포**

마이그레이션이 적용되지 않은 상태에서 프론트엔드만 배포되면 사이트가 깨집니다 (\`get_active_season\`, \`list_seasons\` 등 새 RPC 호출 시 404).

본 PR 작성 시점에 \`supabase db push\` 로 운영 DB에 마이그레이션이 **이미 적용 완료**된 상태입니다:
\`\`\`
Applying migration 20260518000000_us_seasons_schema.sql...
NOTICE: 시즌 시스템 스키마 마이그레이션 완료: 시즌 3개, ACTIVE 1개, DRAFT 1개
Applying migration 20260518000001_us_seasons_rpcs.sql...
NOTICE: US-012 Wave 2 RPC migration applied: 22 season-aware functions
\`\`\`

## Changes

### Database (2 migrations, ~2600 lines)
- \`public.seasons\` 테이블 신규 (status: DRAFT/ACTIVE/ARCHIVED)
  - partial unique index로 ACTIVE/DRAFT 동시 1개만 허용
- \`wallets/markets/orders/positions/transactions\`에 \`season_id NOT NULL\` FK 추가
- \`wallets\` UNIQUE 제약을 \`(user_id)\` → \`(user_id, season_id)\` 로 swap
- 2026-03-28 KST 컷오프 기준으로 기존 데이터를 자동 백필
- 22개 RPC: 5개 신규 (\`get_active_season\`, \`list_seasons\`, \`create_season\`, \`activate_season\`, \`end_season\`) + 17개 기존 RPC를 시즌-인식으로 업데이트
- 모든 거래(BUY/SELL/SETTLE/CANCEL/CLOSE) RPC가 active 시즌이 아닌 마켓을 한국어 에러로 차단

### Frontend
- \`lib/api.ts\`: Season 타입 + 5개 신규 래퍼 + 9개 기존 래퍼에 \`seasonId\` 옵션 추가
- \`app/admin/SeasonManagement.tsx\` (신규 553줄): 시즌 목록/생성/활성화/종료 UI
- \`app/leaderboard\`: 시즌 드롭다운으로 과거 시즌 순위 조회
- \`app/history\`: ORDERS/SETTLEMENTS 탭에 시즌 필터 + 각 행에 "Season N" 배지
- \`app/page.tsx\`: 메인 페이지는 active 시즌 마켓만 노출
- \`app/market/[id]\`: archived 시즌 마켓은 거래 패널을 banner로 교체 (포지션은 표시)

## Verification

### 로컬 테스트 (32 시나리오 통과)
- ✅ 전체 마이그레이션 + seed 적용 통과
- ✅ BUY/SELL/SETTLE 시즌-인식 동작
- ✅ \`activate_season\` 게이트: 미정산 마켓 있을 때 차단, 정산 후 성공 + 자동 1000코인 지급
- ✅ archived 시즌 마켓에서 BUY/SETTLE/CANCEL/CLOSE 모두 hard-block
- ✅ \`create_season\` 입력 검증 + DRAFT 중복 차단
- ✅ Leaderboard ROI 시즌별 정확히 분리 (Season 1 total_granted=5000, Season 2 total_granted=1000)
- ✅ History RPC 시즌 필터링 정확 (NULL → 전체, 특정 ID → 해당 시즌만)

### 발견 + 수정된 버그
- \`activate_season\` / \`login\` 의 \`v_inserted_wallet_id\`를 \`INTEGER\` → \`UUID\` 로 수정 (wallets.id는 UUID)

### Build & Lint
- \`npm run build\`: 12/12 페이지 컴파일 통과
- \`lsp_diagnostics\`: 모든 변경 파일 0 에러
- \`npx tsc --noEmit\`: 0 에러

## Post-merge Checklist (사용자)

1. Vercel 자동 배포 완료 대기
2. 메인 페이지 접속 → "Season 1 활성" pill 확인
3. \`/admin\` → "시즌 관리" 카드 클릭 → Season 2 (DRAFT) 보이는지 확인
4. \`/leaderboard\` → 시즌 드롭다운 동작 확인
5. **5/19 시즌 2 활성화**: Season 1 마켓 모두 정산 후 어드민에서 "시즌 시작" 버튼 클릭

## Out of scope (별도 처리)

- \`supabase/seed.sql\`의 \`DELETE FROM public.predictions\` 제거 (pre-existing 마이그레이션 \`20260304000021\`에서 이미 drop된 테이블 참조 버그) — 시즌 작업 중 발견되어 함께 정리
- \`supabase/config.toml\` 신규 추가 (로컬 \`supabase init\` 산출물, 운영에 영향 없음)