### PR TITLE
feat(admin): 회원 수명주기와 CSV 운영 도구 추가

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,6 +5,7 @@ import AdminAuditLog from "@/components/admin/AdminAuditLog";
 import AdminAuthGate, {
   type AdminControls,
 } from "@/components/admin/AdminAuthGate";
+import MemberManagement from "@/components/admin/MemberManagement";
 import OperatorManagement from "@/components/admin/OperatorManagement";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -2034,6 +2035,7 @@ function AdminDashboard({
     | "dashboard"
     | "operators"
     | "audit"
+    | "members"
     | "seasons"
     | "matches"
     | "coins"
@@ -2062,6 +2064,16 @@ function AdminDashboard({
 
   if (currentView === "audit") {
     return <AdminAuditLog onBack={() => setCurrentView("dashboard")} />;
+  }
+
+  if (currentView === "members") {
+    return (
+      <MemberManagement
+        operator={operator}
+        onBack={() => setCurrentView("dashboard")}
+        onReauthenticate={controls.reauthenticate}
+      />
+    );
   }
 
   if (currentView !== "dashboard") {
@@ -2176,6 +2188,23 @@ function AdminDashboard({
             </Button>
           </Card>
         )}
+
+        <Card className={isMobile ? "p-4" : "p-6"}>
+          <h3
+            className={`font-semibold mb-3 ${isMobile ? "text-lg" : "text-xl"}`}
+          >
+            회원 관리
+          </h3>
+          <p className="text-muted-foreground mb-4">
+            회원 검색, 등록, 비활성화, CSV 반영, 지갑 복구를 관리합니다.
+          </p>
+          <Button
+            onClick={() => setCurrentView("members")}
+            className={isMobile ? "w-full" : ""}
+          >
+            접속
+          </Button>
+        </Card>
 
         <Card className={`rounded-2xl border-tokhin-green/30 bg-tokhin-green/5 ${isMobile ? "p-4" : "p-6"}`}>
           <h3

--- a/app/api/admin/members/[id]/route.ts
+++ b/app/api/admin/members/[id]/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdminSession } from "@/lib/admin/authorization";
+import { adminErrorResponse } from "@/lib/admin/errors";
+import { createAdminServiceClient } from "@/lib/admin/service";
+
+const ActionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("set_active"),
+    isActive: z.boolean(),
+    confirmOpenPositions: z.boolean().default(false),
+    reason: z.string().trim().max(200).nullable().optional(),
+  }),
+  z.object({ action: z.literal("repair_wallet") }),
+  z.object({ action: z.literal("reset_password") }),
+]);
+
+type RouteContext = Readonly<{ params: Promise<{ id: string }> }>;
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext,
+): Promise<NextResponse> {
+  try {
+    await requireAdminSession(request, "operators:read");
+    const { id } = await context.params;
+    const service = createAdminServiceClient();
+    const [{ data: member, error }, { data: impact, error: impactError }] =
+      await Promise.all([
+        service
+          .from("users")
+          .select(
+            "id, student_number, username, phone_number, department, favorite_team_id, password_changed, is_active, session_version, deactivated_at, deactivated_reason",
+          )
+          .eq("id", id)
+          .single(),
+        service.rpc("admin_member_impact", { p_user_id: id }),
+      ]);
+    if (error) throw error;
+    if (impactError) throw impactError;
+    return NextResponse.json({ member, impact });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: RouteContext,
+): Promise<NextResponse> {
+  try {
+    const session = await requireAdminSession(request, "admin:mutate", true);
+    const { id } = await context.params;
+    const input = ActionSchema.parse(await request.json());
+    const service = createAdminServiceClient();
+
+    if (input.action === "set_active") {
+      const { data, error } = await service.rpc("admin_set_member_active", {
+        p_actor_id: session.operator.id,
+        p_user_id: id,
+        p_is_active: input.isActive,
+        p_confirm_open_positions: input.confirmOpenPositions,
+        p_reason: input.reason ?? null,
+      });
+      if (error) throw error;
+      return NextResponse.json({ result: data });
+    }
+
+    if (input.action === "repair_wallet") {
+      const { data, error } = await service.rpc(
+        "admin_repair_member_wallet",
+        {
+          p_actor_id: session.operator.id,
+          p_user_id: id,
+        },
+      );
+      if (error) throw error;
+      return NextResponse.json({ result: data });
+    }
+
+    const { data: member, error: memberError } = await service
+      .from("users")
+      .select(
+        "student_number, username, phone_number, department, favorite_team_id",
+      )
+      .eq("id", id)
+      .single();
+    if (memberError) throw memberError;
+    const { data, error } = await service.rpc("admin_upsert_member", {
+      p_actor_id: session.operator.id,
+      p_member: member,
+      p_reset_password: true,
+    });
+    if (error) throw error;
+    return NextResponse.json({ result: data });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/app/api/admin/members/route.ts
+++ b/app/api/admin/members/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdminSession } from "@/lib/admin/authorization";
+import { adminErrorResponse } from "@/lib/admin/errors";
+import { createAdminServiceClient } from "@/lib/admin/service";
+
+const MemberInputSchema = z.object({
+  student_number: z.number().int().positive(),
+  username: z.string().trim().min(1).max(50),
+  phone_number: z.string().trim().min(10).max(20),
+  department: z.string().trim().min(1).max(100),
+  favorite_team_id: z.number().int().positive(),
+  reset_password: z.boolean().optional(),
+});
+
+const MutationSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("upsert"),
+    member: MemberInputSchema,
+  }),
+  z.object({
+    action: z.literal("bulk_upsert"),
+    members: z.array(MemberInputSchema).min(1).max(500),
+  }),
+]);
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    await requireAdminSession(request, "operators:read");
+    const service = createAdminServiceClient();
+    const query = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+    const activeFilter = request.nextUrl.searchParams.get("active");
+    let usersQuery = service
+      .from("users")
+      .select(
+        "id, student_number, username, phone_number, department, favorite_team_id, password_changed, is_active, session_version, deactivated_at, deactivated_reason, created_at, updated_at, teams(name, short_name)",
+      )
+      .order("student_number", { ascending: true })
+      .limit(200);
+
+    if (query) {
+      const filters = [
+        `username.ilike.%${query}%`,
+        `department.ilike.%${query}%`,
+      ];
+      if (/^[0-9]+$/.test(query)) {
+        filters.push(`student_number.eq.${query}`);
+      }
+      usersQuery = usersQuery.or(filters.join(","));
+    }
+    if (activeFilter === "true" || activeFilter === "false") {
+      usersQuery = usersQuery.eq("is_active", activeFilter === "true");
+    }
+
+    const [{ data: users, error }, { data: activeSeason }, { data: teams }] =
+      await Promise.all([
+        usersQuery,
+        service.from("seasons").select("id").eq("status", "ACTIVE").single(),
+        service.from("teams").select("id, name, short_name").order("id"),
+      ]);
+    if (error) throw error;
+
+    const userIds = (users ?? []).map((user) => user.id);
+    const { data: wallets, error: walletError } =
+      userIds.length > 0 && activeSeason
+        ? await service
+            .from("wallets")
+            .select("user_id, balance")
+            .eq("season_id", activeSeason.id)
+            .in("user_id", userIds)
+        : { data: [], error: null };
+    if (walletError) throw walletError;
+    const walletByUser = new Map(
+      (wallets ?? []).map((wallet) => [
+        wallet.user_id,
+        Number(wallet.balance),
+      ]),
+    );
+
+    return NextResponse.json({
+      members: (users ?? []).map((user) => ({
+        ...user,
+        has_active_wallet: walletByUser.has(user.id),
+        active_wallet_balance: walletByUser.get(user.id) ?? null,
+      })),
+      teams: teams ?? [],
+      activeSeasonId: activeSeason?.id ?? null,
+    });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await requireAdminSession(request, "admin:mutate");
+    const input = MutationSchema.parse(await request.json());
+    const service = createAdminServiceClient();
+
+    if (input.action === "upsert") {
+      const { reset_password: resetPassword = false, ...member } = input.member;
+      const { data, error } = await service.rpc("admin_upsert_member", {
+        p_actor_id: session.operator.id,
+        p_member: member,
+        p_reset_password: resetPassword,
+      });
+      if (error) throw error;
+      return NextResponse.json({ result: data });
+    }
+
+    const { data, error } = await service.rpc("admin_bulk_upsert_members", {
+      p_actor_id: session.operator.id,
+      p_rows: input.members,
+    });
+    if (error) throw error;
+    return NextResponse.json({ result: data });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -52,7 +52,12 @@ export default function LoginPage() {
     try {
       const result = await login(studentNumber.trim(), password);
 
-      if (!result.success || !result.user_id || !result.username) {
+      if (
+        !result.success ||
+        !result.user_id ||
+        !result.username ||
+        typeof result.session_version !== "number"
+      ) {
         setError(result.error || "학번 또는 비밀번호가 올바르지 않습니다");
         setIsLoading(false);
         return;
@@ -62,6 +67,7 @@ export default function LoginPage() {
         user_id: result.user_id,
         username: result.username,
         student_number: studentNumber.trim(),
+        session_version: result.session_version,
       };
 
       if (result.password_changed) {

--- a/components/admin/MemberCsvImport.tsx
+++ b/components/admin/MemberCsvImport.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  memberPreviewToCsv,
+  previewMemberCsv,
+} from "@/lib/admin/member-csv";
+import {
+  bulkUpsertAdminMembers,
+  type AdminMember,
+  type AdminTeamRef,
+} from "@/lib/admin/member-client";
+
+type Props = Readonly<{
+  members: readonly AdminMember[];
+  teams: readonly AdminTeamRef[];
+  onApplied: () => Promise<void>;
+  onReauthenticate: () => Promise<boolean>;
+}>;
+
+export default function MemberCsvImport({
+  members,
+  teams,
+  onApplied,
+  onReauthenticate,
+}: Props) {
+  const [fileName, setFileName] = useState("");
+  const [preview, setPreview] = useState<ReturnType<typeof previewMemberCsv>>(
+    [],
+  );
+  const [message, setMessage] = useState("");
+  const validRows = preview.filter((row) => row.member !== null);
+  const errorCount = preview.filter((row) => row.status === "ERROR").length;
+
+  async function handleFile(file: File | undefined) {
+    setMessage("");
+    const text = file ? await file.text() : "";
+    setFileName(file?.name ?? "");
+    setPreview(text ? previewMemberCsv(text, members, teams) : []);
+  }
+
+  async function handleApply() {
+    if (validRows.length === 0 || !(await onReauthenticate())) return;
+    try {
+      await bulkUpsertAdminMembers(
+        validRows.flatMap((row) => (row.member ? [row.member] : [])),
+      );
+      setMessage(
+        `${validRows.length}개 행을 반영했습니다.${
+          errorCount ? ` 오류 ${errorCount}개는 제외했습니다.` : ""
+        }`,
+      );
+      await onApplied();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "반영에 실패했습니다.");
+    }
+  }
+
+  function downloadResult() {
+    const url = URL.createObjectURL(
+      new Blob([memberPreviewToCsv(preview)], {
+        type: "text/csv;charset=utf-8",
+      }),
+    );
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "member-import-result.csv";
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <Card className="space-y-3 rounded-2xl p-4 shadow">
+      <div>
+        <h2 className="font-bold">CSV 일괄 등록</h2>
+        <p className="text-xs text-muted-foreground">
+          student_number, username, phone_number, department, favorite_team,
+          reset_password
+        </p>
+      </div>
+      <div className="flex items-center gap-2 text-sm">
+        <label className="cursor-pointer rounded-lg border bg-white px-3 py-2 font-semibold">
+          CSV 파일 선택
+          <input
+            aria-label="회원 CSV"
+            className="sr-only"
+            type="file"
+            accept=".csv,text/csv"
+            disabled={teams.length === 0}
+            onChange={(event) => void handleFile(event.target.files?.[0])}
+          />
+        </label>
+        <span className="truncate text-muted-foreground">
+          {fileName || "선택된 파일 없음"}
+        </span>
+      </div>
+      {preview.length > 0 && (
+        <>
+          <div className="max-h-56 space-y-2 overflow-y-auto">
+            {preview.map((row) => (
+              <div
+                key={row.rowNumber}
+                className="rounded-lg border bg-white p-2 text-xs"
+              >
+                <p className="font-semibold">
+                  {row.rowNumber}행 · {row.status}
+                  {row.member ? ` · ${row.member.username}` : ""}
+                </p>
+                {row.errors.map((error) => (
+                  <p key={error} className="text-red-600">
+                    {error}
+                  </p>
+                ))}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Button onClick={() => void handleApply()}>
+              {errorCount ? "유효 행만 반영" : "전체 반영"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setFileName("");
+                setPreview([]);
+              }}
+            >
+              전체 취소
+            </Button>
+            <Button
+              variant="outline"
+              className="col-span-2"
+              onClick={downloadResult}
+            >
+              처리 결과 CSV 다운로드
+            </Button>
+          </div>
+        </>
+      )}
+      {message && <p className="text-sm font-semibold">{message}</p>}
+    </Card>
+  );
+}

--- a/components/admin/MemberEditor.tsx
+++ b/components/admin/MemberEditor.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type {
+  AdminMemberInput,
+  AdminTeamRef,
+} from "@/lib/admin/member-client";
+
+type Props = Readonly<{
+  form: AdminMemberInput;
+  editing: boolean;
+  teams: readonly AdminTeamRef[];
+  onChange: (form: AdminMemberInput) => void;
+  onSave: (resetPassword: boolean) => Promise<void>;
+}>;
+
+export default function MemberEditor({
+  form,
+  editing,
+  teams,
+  onChange,
+  onSave,
+}: Props) {
+  return (
+    <Card className="space-y-3 rounded-2xl p-4 shadow">
+      <h2 className="font-bold">{editing ? "회원 수정" : "회원 추가"}</h2>
+      <Input
+        type="number"
+        placeholder="학번"
+        value={form.student_number || ""}
+        disabled={editing}
+        onChange={(event) =>
+          onChange({ ...form, student_number: Number(event.target.value) })
+        }
+      />
+      <Input
+        placeholder="이름"
+        value={form.username}
+        onChange={(event) => onChange({ ...form, username: event.target.value })}
+      />
+      <Input
+        placeholder="전화번호"
+        value={form.phone_number}
+        onChange={(event) =>
+          onChange({ ...form, phone_number: event.target.value })
+        }
+      />
+      <Input
+        placeholder="학과"
+        value={form.department}
+        onChange={(event) =>
+          onChange({ ...form, department: event.target.value })
+        }
+      />
+      <select
+        aria-label="선호팀"
+        className="h-11 w-full rounded-lg border bg-white px-3"
+        value={form.favorite_team_id || ""}
+        onChange={(event) =>
+          onChange({ ...form, favorite_team_id: Number(event.target.value) })
+        }
+      >
+        <option value="">선호팀 선택</option>
+        {teams.map((team) => (
+          <option key={team.id} value={team.id}>
+            {team.name}
+          </option>
+        ))}
+      </select>
+      <div className="grid grid-cols-2 gap-2">
+        <Button onClick={() => void onSave(false)}>저장</Button>
+        <Button variant="outline" onClick={() => void onSave(true)}>
+          저장 + 비밀번호 초기화
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/components/admin/MemberManagement.tsx
+++ b/components/admin/MemberManagement.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import MemberCsvImport from "@/components/admin/MemberCsvImport";
+import MemberEditor from "@/components/admin/MemberEditor";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  getAdminMemberImpact,
+  listAdminMembers,
+  repairAdminMemberWallet,
+  resetAdminMemberPassword,
+  setAdminMemberActive,
+  upsertAdminMember,
+  type AdminMember,
+  type AdminMemberInput,
+  type AdminTeamRef,
+} from "@/lib/admin/member-client";
+import type { AdminOperator } from "@/lib/admin/types";
+
+type Props = Readonly<{
+  operator: AdminOperator;
+  onBack: () => void;
+  onReauthenticate: () => Promise<boolean>;
+}>;
+const EMPTY_FORM: AdminMemberInput = {
+  student_number: 0,
+  username: "",
+  phone_number: "",
+  department: "",
+  favorite_team_id: 0,
+};
+const formatCoins = (value: number | null): string =>
+  new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 2 }).format(
+    value ?? 0,
+  );
+export default function MemberManagement({
+  operator,
+  onBack,
+  onReauthenticate,
+}: Props) {
+  const [members, setMembers] = useState<AdminMember[]>([]);
+  const [teams, setTeams] = useState<AdminTeamRef[]>([]);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState<"all" | "active" | "inactive">("all");
+  const [form, setForm] = useState<AdminMemberInput>(EMPTY_FORM);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [message, setMessage] = useState("");
+
+  const loadMembers = useCallback(async () => {
+    try {
+      const data = await listAdminMembers(query, active);
+      setMembers(data.members);
+      setTeams(data.teams);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "조회에 실패했습니다.");
+    }
+  }, [active, query]);
+
+  useEffect(() => {
+    void loadMembers();
+  }, [loadMembers]);
+
+  function editMember(member: AdminMember) {
+    setEditingId(member.id);
+    setForm({
+      student_number: member.student_number,
+      username: member.username,
+      phone_number: member.phone_number,
+      department: member.department,
+      favorite_team_id: member.favorite_team_id,
+    });
+  }
+
+  async function saveMember(resetPassword = false) {
+    if (!(await onReauthenticate())) return;
+    try {
+      await upsertAdminMember({ ...form, reset_password: resetPassword });
+      setMessage(
+        resetPassword ? "회원 정보와 초기 비밀번호를 갱신했습니다." : "회원 정보를 저장했습니다.",
+      );
+      setForm(EMPTY_FORM);
+      setEditingId(null);
+      await loadMembers();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "저장에 실패했습니다.");
+    }
+  }
+
+  async function toggleMember(member: AdminMember) {
+    try {
+      const impact = await getAdminMemberImpact(member.id);
+      const confirmation = member.is_active
+        ? window.confirm(
+            `미정산 포지션 ${impact.open_position_count}개와 기록은 유지됩니다. 비활성화할까요?`,
+          )
+        : true;
+      if (!confirmation || !(await onReauthenticate())) return;
+      await setAdminMemberActive(
+        member.id,
+        !member.is_active,
+        confirmation,
+        member.is_active ? "관리자 비활성화" : undefined,
+      );
+      setMessage(member.is_active ? "회원을 비활성화했습니다." : "회원을 재활성화했습니다.");
+      await loadMembers();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "상태 변경에 실패했습니다.");
+    }
+  }
+
+  async function repairWallet(member: AdminMember) {
+    try {
+      if (!(await onReauthenticate())) return;
+      await repairAdminMemberWallet(member.id);
+      setMessage("활성 시즌 지갑을 복구했습니다.");
+      await loadMembers();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "지갑 복구에 실패했습니다.");
+    }
+  }
+
+  async function resetPassword(member: AdminMember) {
+    try {
+      if (!(await onReauthenticate())) return;
+      await resetAdminMemberPassword(member.id);
+      setMessage("전화번호 기준 초기 비밀번호로 재설정했습니다.");
+      await loadMembers();
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : "비밀번호 초기화에 실패했습니다.",
+      );
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen max-w-[430px] space-y-4 bg-gray-50 px-5 py-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-semibold text-tokhin-green">MEMBERS</p>
+          <h1 className="text-2xl font-bold">회원 관리</h1>
+        </div>
+        <Button variant="outline" onClick={onBack}>
+          돌아가기
+        </Button>
+      </div>
+
+      <Card className="space-y-3 rounded-2xl p-4 shadow">
+        <div className="flex gap-2">
+          <Input
+            placeholder="학번, 이름, 학과 검색"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <Button variant="outline" onClick={() => void loadMembers()}>
+            검색
+          </Button>
+        </div>
+        <select
+          aria-label="회원 상태"
+          className="h-11 w-full rounded-lg border bg-white px-3"
+          value={active}
+          onChange={(event) =>
+            setActive(event.target.value as "all" | "active" | "inactive")
+          }
+        >
+          <option value="all">전체</option>
+          <option value="active">활성</option>
+          <option value="inactive">비활성</option>
+        </select>
+      </Card>
+
+      {operator.role !== "VIEWER" && (
+        <MemberEditor
+          form={form}
+          editing={editingId !== null}
+          teams={teams}
+          onChange={setForm}
+          onSave={saveMember}
+        />
+      )}
+
+      {operator.role !== "VIEWER" && (
+        <MemberCsvImport
+          members={members}
+          teams={teams}
+          onApplied={loadMembers}
+          onReauthenticate={onReauthenticate}
+        />
+      )}
+
+      {message && <p className="text-sm font-semibold">{message}</p>}
+      <div className="space-y-3">
+        {members.map((member) => (
+          <Card
+            key={member.id}
+            data-testid={`member-${member.student_number}`}
+            className="rounded-2xl p-4 shadow"
+          >
+            <div className="flex justify-between gap-3">
+              <div>
+                <p className="font-bold">
+                  {member.username} · {member.student_number}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {member.department} · {member.teams?.short_name ?? "팀 없음"}
+                </p>
+                <p className="text-sm">
+                  지갑:{" "}
+                  {member.has_active_wallet
+                    ? `${formatCoins(member.active_wallet_balance)}코인`
+                    : "누락"}
+                </p>
+              </div>
+              <span className={member.is_active ? "text-green-600" : "text-gray-500"}>
+                {member.is_active ? "활성" : "비활성"}
+              </span>
+            </div>
+            {operator.role !== "VIEWER" && (
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <Button variant="outline" onClick={() => editMember(member)}>
+                  수정
+                </Button>
+                <Button variant="outline" onClick={() => void toggleMember(member)}>
+                  {member.is_active ? "비활성화" : "재활성화"}
+                </Button>
+                {!member.has_active_wallet && member.is_active && (
+                  <Button
+                    variant="outline"
+                    onClick={() => void repairWallet(member)}
+                  >
+                    지갑 복구
+                  </Button>
+                )}
+                <Button
+                  variant="outline"
+                  onClick={() => void resetPassword(member)}
+                >
+                  비밀번호 초기화
+                </Button>
+              </div>
+            )}
+          </Card>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/lib/admin/member-client.ts
+++ b/lib/admin/member-client.ts
@@ -1,0 +1,137 @@
+export type AdminMember = Readonly<{
+  id: string;
+  student_number: number;
+  username: string;
+  phone_number: string;
+  department: string;
+  favorite_team_id: number;
+  password_changed: boolean;
+  is_active: boolean;
+  session_version: number;
+  deactivated_at: string | null;
+  deactivated_reason: string | null;
+  has_active_wallet: boolean;
+  active_wallet_balance: number | null;
+  teams: Readonly<{ name: string; short_name: string }> | null;
+}>;
+
+export type AdminTeamRef = Readonly<{
+  id: number;
+  name: string;
+  short_name: string;
+}>;
+
+export type AdminMemberInput = Readonly<{
+  student_number: number;
+  username: string;
+  phone_number: string;
+  department: string;
+  favorite_team_id: number;
+  reset_password?: boolean;
+}>;
+
+type MembersResponse = Readonly<{
+  members: AdminMember[];
+  teams: AdminTeamRef[];
+  activeSeasonId: number | null;
+}>;
+
+async function readJson<T>(response: Response): Promise<T> {
+  const body = (await response.json()) as T & { error?: string };
+  if (!response.ok) throw new Error(body.error ?? "회원 관리 요청에 실패했습니다.");
+  return body;
+}
+
+export async function listAdminMembers(
+  query = "",
+  active: "all" | "active" | "inactive" = "all",
+): Promise<MembersResponse> {
+  const params = new URLSearchParams();
+  if (query.trim()) params.set("q", query.trim());
+  if (active !== "all") params.set("active", String(active === "active"));
+  const response = await fetch(`/api/admin/members?${params}`, {
+    credentials: "same-origin",
+    cache: "no-store",
+  });
+  return readJson<MembersResponse>(response);
+}
+
+export async function upsertAdminMember(
+  member: AdminMemberInput,
+): Promise<unknown> {
+  const response = await fetch("/api/admin/members", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "upsert", member }),
+  });
+  return (await readJson<{ result: unknown }>(response)).result;
+}
+
+export async function bulkUpsertAdminMembers(
+  members: readonly AdminMemberInput[],
+): Promise<unknown> {
+  const response = await fetch("/api/admin/members", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "bulk_upsert", members }),
+  });
+  return (await readJson<{ result: unknown }>(response)).result;
+}
+
+export async function getAdminMemberImpact(
+  id: string,
+): Promise<
+  Readonly<{
+    open_position_count: number;
+    active_wallet_balance: number | null;
+    has_active_wallet: boolean;
+  }>
+> {
+  const response = await fetch(`/api/admin/members/${id}`, {
+    credentials: "same-origin",
+    cache: "no-store",
+  });
+  return (
+    await readJson<{
+      impact: {
+        open_position_count: number;
+        active_wallet_balance: number | null;
+        has_active_wallet: boolean;
+      };
+    }>(response)
+  ).impact;
+}
+
+async function patchMember(id: string, body: unknown): Promise<void> {
+  const response = await fetch(`/api/admin/members/${id}`, {
+    method: "PATCH",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  await readJson<{ result: unknown }>(response);
+}
+
+export async function setAdminMemberActive(
+  id: string,
+  isActive: boolean,
+  confirmOpenPositions: boolean,
+  reason?: string,
+): Promise<void> {
+  await patchMember(id, {
+    action: "set_active",
+    isActive,
+    confirmOpenPositions,
+    reason,
+  });
+}
+
+export async function repairAdminMemberWallet(id: string): Promise<void> {
+  await patchMember(id, { action: "repair_wallet" });
+}
+
+export async function resetAdminMemberPassword(id: string): Promise<void> {
+  await patchMember(id, { action: "reset_password" });
+}

--- a/lib/admin/member-csv.ts
+++ b/lib/admin/member-csv.ts
@@ -1,0 +1,150 @@
+import type {
+  AdminMember,
+  AdminMemberInput,
+  AdminTeamRef,
+} from "@/lib/admin/member-client";
+
+export type MemberCsvPreview = Readonly<{
+  rowNumber: number;
+  status: "CREATE" | "UPDATE" | "ERROR";
+  member: AdminMemberInput | null;
+  errors: readonly string[];
+}>;
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let value = "";
+  let quoted = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (character === '"') {
+      if (quoted && line[index + 1] === '"') {
+        value += '"';
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (character === "," && !quoted) {
+      cells.push(value.trim());
+      value = "";
+    } else {
+      value += character;
+    }
+  }
+  cells.push(value.trim());
+  return cells;
+}
+
+function normalizePhone(value: string): string {
+  return value.replace(/\D/g, "");
+}
+
+export function previewMemberCsv(
+  csv: string,
+  members: readonly AdminMember[],
+  teams: readonly AdminTeamRef[],
+): MemberCsvPreview[] {
+  const lines = csv.replace(/^\uFEFF/, "").split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) return [];
+
+  const headers = parseCsvLine(lines[0]).map((value) => value.toLowerCase());
+  const required = [
+    "student_number",
+    "username",
+    "phone_number",
+    "department",
+    "favorite_team",
+  ];
+  if (required.some((header) => !headers.includes(header))) {
+    return [
+      {
+        rowNumber: 1,
+        status: "ERROR",
+        member: null,
+        errors: [`필수 헤더: ${required.join(", ")}`],
+      },
+    ];
+  }
+
+  const existing = new Set(members.map((member) => member.student_number));
+  const seen = new Set<number>();
+  const teamByLabel = new Map<string, number>();
+  for (const team of teams) {
+    teamByLabel.set(String(team.id), team.id);
+    teamByLabel.set(team.name.toLowerCase(), team.id);
+    teamByLabel.set(team.short_name.toLowerCase(), team.id);
+  }
+
+  return lines.slice(1).map((line, rowIndex) => {
+    const values = parseCsvLine(line);
+    const row = Object.fromEntries(
+      headers.map((header, index) => [header, values[index] ?? ""]),
+    );
+    const errors: string[] = [];
+    const studentNumber = Number(row.student_number);
+    const phone = normalizePhone(row.phone_number);
+    const teamId = teamByLabel.get(row.favorite_team.toLowerCase());
+
+    if (!Number.isSafeInteger(studentNumber) || studentNumber <= 0) {
+      errors.push("학번은 양의 정수여야 합니다.");
+    } else if (seen.has(studentNumber)) {
+      errors.push("CSV 안에 중복 학번이 있습니다.");
+    } else {
+      seen.add(studentNumber);
+    }
+    if (!row.username.trim()) errors.push("이름은 필수입니다.");
+    if (!row.department.trim()) errors.push("학과는 필수입니다.");
+    if (!/^01[016789][0-9]{7,8}$/.test(phone)) {
+      errors.push("전화번호 형식이 올바르지 않습니다.");
+    }
+    if (!teamId) errors.push("선호팀을 찾을 수 없습니다.");
+
+    const member =
+      errors.length === 0 && teamId
+        ? {
+            student_number: studentNumber,
+            username: row.username.trim(),
+            phone_number: phone,
+            department: row.department.trim(),
+            favorite_team_id: teamId,
+            reset_password: /^(1|true|yes)$/i.test(row.reset_password ?? ""),
+          }
+        : null;
+
+    return {
+      rowNumber: rowIndex + 2,
+      status:
+        errors.length > 0
+          ? "ERROR"
+          : existing.has(studentNumber)
+            ? "UPDATE"
+            : "CREATE",
+      member,
+      errors,
+    };
+  });
+}
+
+function escapeCsv(value: unknown): string {
+  const text = String(value ?? "");
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+export function memberPreviewToCsv(rows: readonly MemberCsvPreview[]): string {
+  const lines = [
+    ["row", "status", "student_number", "username", "errors"].join(","),
+    ...rows.map((row) =>
+      [
+        row.rowNumber,
+        row.status,
+        row.member?.student_number ?? "",
+        row.member?.username ?? "",
+        row.errors.join(" / "),
+      ]
+        .map(escapeCsv)
+        .join(","),
+    ),
+  ];
+  return `\uFEFF${lines.join("\n")}`;
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -21,6 +21,7 @@ interface LoginRpcResponse {
   user_id?: string;
   username?: string;
   password_changed?: boolean;
+  session_version?: number;
   error?: string;
 }
 
@@ -787,6 +788,7 @@ export const login = async (
     user_id: data.user_id,
     username: data.username,
     password_changed: data.password_changed,
+    session_version: data.session_version,
   };
 };
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,10 @@
+import { createClient } from "@/lib/supabase/client";
+
 export interface UserSession {
   user_id: string;
   username: string;
   student_number: string;
+  session_version: number;
 }
 
 export const USER_SESSION_KEY = "tokhin_user_session";
@@ -24,12 +27,14 @@ const parseSession = (value: string | null): UserSession | null => {
     if (
       typeof parsed.user_id === "string" &&
       typeof parsed.username === "string" &&
-      typeof parsed.student_number === "string"
+      typeof parsed.student_number === "string" &&
+      typeof parsed.session_version === "number"
     ) {
       return {
         user_id: parsed.user_id,
         username: parsed.username,
         student_number: parsed.student_number,
+        session_version: parsed.session_version,
       };
     }
   } catch {
@@ -77,4 +82,17 @@ export const clearPendingPasswordChangeSession = () => {
 export const clearAllAuthState = () => {
   clearUserSession();
   clearPendingPasswordChangeSession();
+};
+
+export const validateUserSession = async (
+  session: UserSession,
+): Promise<boolean> => {
+  const { data, error } = await createClient().rpc("validate_user_session", {
+    p_user_id: session.user_id,
+    p_session_version: session.session_version,
+  });
+
+  if (error) return false;
+  const result = data as { success?: boolean; valid?: boolean } | null;
+  return result?.success === true && result.valid === true;
 };

--- a/lib/hooks/useUserSession.ts
+++ b/lib/hooks/useUserSession.ts
@@ -3,10 +3,12 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
+  clearUserSession,
   getUserSession,
   type UserSession,
   USER_SESSION_CHANGED_EVENT,
   USER_SESSION_KEY,
+  validateUserSession,
 } from "@/lib/auth";
 
 interface UseUserSessionOptions {
@@ -21,25 +23,38 @@ export const useUserSession = ({
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const syncSession = () => {
-      setSession(getUserSession());
+    let active = true;
+
+    const syncSession = async () => {
+      const storedSession = getUserSession();
+      const isValid =
+        storedSession !== null && (await validateUserSession(storedSession));
+
+      if (!active) return;
+      if (storedSession && !isValid) clearUserSession();
+      setSession(isValid ? storedSession : null);
+      setIsLoading(false);
     };
 
-    syncSession();
-    setIsLoading(false);
+    void syncSession();
 
     const handleStorage = (event: StorageEvent) => {
       if (event.key === null || event.key === USER_SESSION_KEY) {
-        syncSession();
+        void syncSession();
       }
     };
 
+    const handleSessionChanged = () => void syncSession();
     window.addEventListener("storage", handleStorage);
-    window.addEventListener(USER_SESSION_CHANGED_EVENT, syncSession);
+    window.addEventListener(USER_SESSION_CHANGED_EVENT, handleSessionChanged);
 
     return () => {
+      active = false;
       window.removeEventListener("storage", handleStorage);
-      window.removeEventListener(USER_SESSION_CHANGED_EVENT, syncSession);
+      window.removeEventListener(
+        USER_SESSION_CHANGED_EVENT,
+        handleSessionChanged,
+      );
     };
   }, []);
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,7 @@ delete process.env.NO_COLOR;
 export default defineConfig({
   testDir: "./tests/e2e",
   globalSetup: "./tests/e2e/global-setup.ts",
+  globalTeardown: "./tests/e2e/global-teardown.ts",
   fullyParallel: false,
   forbidOnly: true,
   retries: 0,

--- a/supabase/migrations/20260802000037_member_management.sql
+++ b/supabase/migrations/20260802000037_member_management.sql
@@ -1,0 +1,871 @@
+-- Issue #37: atomic member lifecycle management.
+
+alter table public.users
+  add column if not exists is_active boolean not null default true,
+  add column if not exists session_version integer not null default 1,
+  add column if not exists deactivated_at timestamptz,
+  add column if not exists deactivated_reason text;
+
+insert into public.settings (key, value)
+values ('member_initial_grant', '{"amount": 1000}'::jsonb)
+on conflict (key) do nothing;
+
+create or replace function public.require_admin_operator(
+  p_actor_id uuid,
+  p_owner_only boolean default false
+)
+returns public.admin_role
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_role public.admin_role;
+begin
+  select role
+  into v_role
+  from public.admin_operators
+  where id = p_actor_id
+    and is_active = true;
+
+  if not found then
+    raise exception '활성 운영자 권한을 확인할 수 없습니다';
+  end if;
+
+  if p_owner_only and v_role <> 'OWNER' then
+    raise exception 'OWNER 권한이 필요합니다';
+  end if;
+
+  if not p_owner_only and v_role = 'VIEWER' then
+    raise exception '변경 권한이 없습니다';
+  end if;
+
+  return v_role;
+end;
+$$;
+
+create or replace function public.admin_upsert_member(
+  p_actor_id uuid,
+  p_member jsonb,
+  p_reset_password boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_before public.users%rowtype;
+  v_after public.users%rowtype;
+  v_student_number bigint;
+  v_username text;
+  v_phone text;
+  v_department text;
+  v_team_id integer;
+  v_action text;
+  v_active_season_id integer;
+  v_initial_grant numeric;
+  v_inserted_wallet_id uuid;
+begin
+  perform public.require_admin_operator(p_actor_id);
+
+  if coalesce(p_member->>'student_number', '') !~ '^[0-9]+$' then
+    raise exception '학번은 숫자만 입력해야 합니다';
+  end if;
+  v_student_number := (p_member->>'student_number')::bigint;
+  v_username := btrim(coalesce(p_member->>'username', ''));
+  v_phone := regexp_replace(coalesce(p_member->>'phone_number', ''), '[^0-9]', '', 'g');
+  v_department := btrim(coalesce(p_member->>'department', ''));
+
+  if coalesce(p_member->>'favorite_team_id', '') !~ '^[0-9]+$' then
+    raise exception '선호팀을 선택해주세요';
+  end if;
+  v_team_id := (p_member->>'favorite_team_id')::integer;
+
+  if v_username = '' then
+    raise exception '이름은 필수입니다';
+  end if;
+  if v_department = '' then
+    raise exception '학과는 필수입니다';
+  end if;
+  if v_phone !~ '^01[016789][0-9]{7,8}$' then
+    raise exception '전화번호 형식이 올바르지 않습니다';
+  end if;
+  if not exists (select 1 from public.teams where id = v_team_id) then
+    raise exception '선호팀 정보를 찾을 수 없습니다';
+  end if;
+
+  select *
+  into v_before
+  from public.users
+  where student_number = v_student_number
+  for update;
+
+  if not found then
+    insert into public.users (
+      student_number,
+      username,
+      phone_number,
+      department,
+      type,
+      favorite_team_id,
+      password_hash,
+      password_changed,
+      is_active,
+      session_version
+    )
+    values (
+      v_student_number,
+      v_username,
+      v_phone,
+      v_department,
+      'STUDENT',
+      v_team_id,
+      encode(digest(v_phone, 'sha256'), 'hex'),
+      false,
+      true,
+      1
+    )
+    returning * into v_after;
+    v_action := 'CREATE';
+
+    select id
+    into v_active_season_id
+    from public.seasons
+    where status = 'ACTIVE'
+    limit 1;
+
+    if v_active_season_id is null then
+      raise exception '활성 시즌을 찾을 수 없습니다';
+    end if;
+
+    select coalesce((value->>'amount')::numeric, 1000)
+    into v_initial_grant
+    from public.settings
+    where key = 'member_initial_grant';
+    v_initial_grant := coalesce(v_initial_grant, 1000);
+
+    insert into public.wallets (
+      user_id, season_id, balance, created_at, updated_at
+    )
+    values (
+      v_after.id, v_active_season_id, v_initial_grant, now(), now()
+    )
+    on conflict (user_id, season_id) do nothing
+    returning id into v_inserted_wallet_id;
+
+    if v_inserted_wallet_id is not null then
+      insert into public.transactions (
+        user_id, type, amount, balance_after, reference_id,
+        description, season_id
+      )
+      values (
+        v_after.id, 'SEASON_GRANT', v_initial_grant, v_initial_grant, null,
+        '신규 회원 시즌 시작 코인 지급', v_active_season_id
+      );
+    end if;
+  else
+    update public.users
+    set
+      username = v_username,
+      phone_number = v_phone,
+      department = v_department,
+      favorite_team_id = v_team_id,
+      password_hash = case
+        when p_reset_password then encode(digest(v_phone, 'sha256'), 'hex')
+        else password_hash
+      end,
+      password_changed = case
+        when p_reset_password then false
+        else password_changed
+      end,
+      session_version = case
+        when p_reset_password then session_version + 1
+        else session_version
+      end,
+      updated_at = now()
+    where id = v_before.id
+    returning * into v_after;
+    v_action := 'UPDATE';
+  end if;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_actor_id,
+    'ADMIN_MEMBER_' || v_action,
+    'user',
+    v_after.id::text,
+    case when v_action = 'UPDATE' then to_jsonb(v_before) else null end,
+    to_jsonb(v_after) - 'password_hash',
+    true
+  );
+
+  return jsonb_build_object(
+    'success', true,
+    'action', v_action,
+    'user_id', v_after.id,
+    'student_number', v_after.student_number,
+    'password_reset', p_reset_password,
+    'wallet_created', v_inserted_wallet_id is not null
+  );
+end;
+$$;
+
+create or replace function public.admin_bulk_upsert_members(
+  p_actor_id uuid,
+  p_rows jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_row jsonb;
+  v_result jsonb;
+  v_results jsonb := '[]'::jsonb;
+begin
+  perform public.require_admin_operator(p_actor_id);
+  if jsonb_typeof(p_rows) <> 'array' then
+    raise exception '회원 일괄 데이터는 배열이어야 합니다';
+  end if;
+
+  for v_row in select value from jsonb_array_elements(p_rows)
+  loop
+    v_result := public.admin_upsert_member(
+      p_actor_id,
+      v_row,
+      coalesce((v_row->>'reset_password')::boolean, false)
+    );
+    v_results := v_results || jsonb_build_array(v_result);
+  end loop;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, after_state, success
+  )
+  values (
+    p_actor_id,
+    'ADMIN_MEMBER_BULK_APPLY',
+    'user',
+    jsonb_build_object('results', v_results),
+    true
+  );
+
+  return jsonb_build_object('success', true, 'results', v_results);
+end;
+$$;
+
+create or replace function public.admin_member_impact(p_user_id uuid)
+returns jsonb
+language sql
+security definer
+set search_path = public, extensions
+as $$
+  select jsonb_build_object(
+    'open_position_count',
+    (
+      select count(*)
+      from public.positions p
+      join public.markets m on m.id = p.market_id
+      where p.user_id = p_user_id
+        and p.quantity > 0
+        and m.status in ('OPEN', 'CLOSED')
+    ),
+    'active_wallet_balance',
+    (
+      select w.balance
+      from public.wallets w
+      join public.seasons s on s.id = w.season_id and s.status = 'ACTIVE'
+      where w.user_id = p_user_id
+      limit 1
+    ),
+    'has_active_wallet',
+    exists (
+      select 1
+      from public.wallets w
+      join public.seasons s on s.id = w.season_id and s.status = 'ACTIVE'
+      where w.user_id = p_user_id
+    )
+  );
+$$;
+
+create or replace function public.admin_set_member_active(
+  p_actor_id uuid,
+  p_user_id uuid,
+  p_is_active boolean,
+  p_confirm_open_positions boolean default false,
+  p_reason text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_before public.users%rowtype;
+  v_after public.users%rowtype;
+  v_impact jsonb;
+begin
+  perform public.require_admin_operator(p_actor_id);
+  select * into v_before from public.users where id = p_user_id for update;
+  if not found then
+    raise exception '회원 정보를 찾을 수 없습니다';
+  end if;
+
+  v_impact := public.admin_member_impact(p_user_id);
+  if not p_is_active
+     and (v_impact->>'open_position_count')::integer > 0
+     and not p_confirm_open_positions then
+    raise exception '미정산 포지션이 있어 영향 확인이 필요합니다';
+  end if;
+
+  update public.users
+  set
+    is_active = p_is_active,
+    session_version = session_version + 1,
+    deactivated_at = case when p_is_active then null else now() end,
+    deactivated_reason = case when p_is_active then null else p_reason end,
+    updated_at = now()
+  where id = p_user_id
+  returning * into v_after;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_actor_id,
+    case when p_is_active
+      then 'ADMIN_MEMBER_REACTIVATED'
+      else 'ADMIN_MEMBER_DEACTIVATED'
+    end,
+    'user',
+    p_user_id::text,
+    to_jsonb(v_before) - 'password_hash',
+    jsonb_build_object(
+      'member', to_jsonb(v_after) - 'password_hash',
+      'impact', v_impact
+    ),
+    true
+  );
+
+  return jsonb_build_object(
+    'success', true,
+    'user_id', p_user_id,
+    'is_active', p_is_active,
+    'session_version', v_after.session_version,
+    'impact', v_impact
+  );
+end;
+$$;
+
+create or replace function public.admin_repair_member_wallet(
+  p_actor_id uuid,
+  p_user_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_user public.users%rowtype;
+  v_season_id integer;
+  v_initial_grant numeric;
+  v_wallet_id uuid;
+begin
+  perform public.require_admin_operator(p_actor_id);
+  select * into v_user from public.users where id = p_user_id for update;
+  if not found then
+    raise exception '회원 정보를 찾을 수 없습니다';
+  end if;
+  if not v_user.is_active then
+    raise exception '비활성 회원의 지갑은 복구할 수 없습니다';
+  end if;
+
+  select id into v_season_id
+  from public.seasons where status = 'ACTIVE' limit 1;
+  if v_season_id is null then
+    raise exception '활성 시즌이 없습니다';
+  end if;
+
+  select coalesce((value->>'amount')::numeric, 1000)
+  into v_initial_grant
+  from public.settings where key = 'member_initial_grant';
+  v_initial_grant := coalesce(v_initial_grant, 1000);
+
+  insert into public.wallets (
+    user_id, season_id, balance, created_at, updated_at
+  )
+  values (p_user_id, v_season_id, v_initial_grant, now(), now())
+  on conflict (user_id, season_id) do nothing
+  returning id into v_wallet_id;
+
+  if v_wallet_id is not null then
+    insert into public.transactions (
+      user_id, type, amount, balance_after, reference_id,
+      description, season_id
+    )
+    values (
+      p_user_id, 'SEASON_GRANT', v_initial_grant, v_initial_grant, null,
+      '누락 활성 시즌 지갑 복구', v_season_id
+    );
+  end if;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id, after_state, success
+  )
+  values (
+    p_actor_id,
+    'ADMIN_MEMBER_WALLET_REPAIRED',
+    'user',
+    p_user_id::text,
+    jsonb_build_object(
+      'season_id', v_season_id,
+      'created', v_wallet_id is not null,
+      'initial_grant', v_initial_grant
+    ),
+    true
+  );
+
+  return jsonb_build_object(
+    'success', true,
+    'user_id', p_user_id,
+    'season_id', v_season_id,
+    'created', v_wallet_id is not null,
+    'initial_grant', v_initial_grant
+  );
+end;
+$$;
+
+create or replace function public.login(
+  p_student_number bigint,
+  p_password text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_user record;
+  v_input_hash text;
+  v_active public.seasons%rowtype;
+  v_inserted_wallet_id uuid;
+  v_initial_grant numeric;
+begin
+  select
+    id, username, password_hash, password_changed,
+    is_active, session_version
+  into v_user
+  from public.users
+  where student_number = p_student_number
+  limit 1;
+
+  v_input_hash := encode(digest(coalesce(p_password, ''), 'sha256'), 'hex');
+  if not found
+     or not v_user.is_active
+     or v_user.password_hash is null
+     or v_user.password_hash <> v_input_hash then
+    return jsonb_build_object(
+      'success', false,
+      'error', '학번 또는 비밀번호가 올바르지 않습니다'
+    );
+  end if;
+
+  select * into v_active
+  from public.seasons where status = 'ACTIVE' limit 1;
+  if not found then
+    return jsonb_build_object(
+      'success', false,
+      'error', 'login 처리 중 활성 시즌을 찾을 수 없습니다'
+    );
+  end if;
+
+  select coalesce((value->>'amount')::numeric, 1000)
+  into v_initial_grant
+  from public.settings where key = 'member_initial_grant';
+  v_initial_grant := coalesce(v_initial_grant, 1000);
+
+  insert into public.wallets (user_id, season_id, balance, created_at, updated_at)
+  values (v_user.id, v_active.id, v_initial_grant, now(), now())
+  on conflict (user_id, season_id) do nothing
+  returning id into v_inserted_wallet_id;
+
+  if v_inserted_wallet_id is not null then
+    insert into public.transactions (
+      user_id, type, amount, balance_after, reference_id,
+      description, created_at, season_id
+    )
+    values (
+      v_user.id, 'SEASON_GRANT', v_initial_grant, v_initial_grant, null,
+      '시즌 시작 코인 지급', now(), v_active.id
+    );
+  end if;
+
+  return jsonb_build_object(
+    'success', true,
+    'user_id', v_user.id,
+    'username', v_user.username,
+    'password_changed', coalesce(v_user.password_changed, false),
+    'session_version', v_user.session_version
+  );
+end;
+$$;
+
+create or replace function public.validate_user_session(
+  p_user_id uuid,
+  p_session_version integer
+)
+returns jsonb
+language sql
+security definer
+set search_path = public, extensions
+as $$
+  select case
+    when exists (
+      select 1
+      from public.users
+      where id = p_user_id
+        and is_active = true
+        and session_version = p_session_version
+    )
+    then jsonb_build_object('success', true, 'valid', true)
+    else jsonb_build_object('success', true, 'valid', false)
+  end;
+$$;
+
+do $$
+begin
+  if to_regprocedure(
+    'public.execute_buy_order_unchecked(uuid,integer,text,numeric)'
+  ) is null then
+    alter function public.execute_buy_order(uuid, integer, text, numeric)
+      rename to execute_buy_order_unchecked;
+  end if;
+  if to_regprocedure(
+    'public.execute_sell_order_unchecked(uuid,integer,text,numeric)'
+  ) is null then
+    alter function public.execute_sell_order(uuid, integer, text, numeric)
+      rename to execute_sell_order_unchecked;
+  end if;
+end;
+$$;
+
+create or replace function public.execute_buy_order(
+  p_user_id uuid,
+  p_market_id integer,
+  p_outcome text,
+  p_quantity numeric
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+begin
+  if not exists (
+    select 1 from public.users
+    where id = p_user_id and is_active = true
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error', '비활성 회원은 거래할 수 없습니다'
+    );
+  end if;
+  return public.execute_buy_order_unchecked(
+    p_user_id, p_market_id, p_outcome, p_quantity
+  );
+end;
+$$;
+
+create or replace function public.execute_sell_order(
+  p_user_id uuid,
+  p_market_id integer,
+  p_outcome text,
+  p_quantity numeric
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+begin
+  if not exists (
+    select 1 from public.users
+    where id = p_user_id and is_active = true
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error', '비활성 회원은 거래할 수 없습니다'
+    );
+  end if;
+  return public.execute_sell_order_unchecked(
+    p_user_id, p_market_id, p_outcome, p_quantity
+  );
+end;
+$$;
+
+create or replace function public.distribute_weekly_coins(
+  p_amount numeric default 300
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_season_id integer;
+  v_users_count integer;
+begin
+  if p_amount is null or p_amount <= 0 then
+    raise exception '지급 코인은 0보다 커야 합니다';
+  end if;
+  select id into v_season_id
+  from public.seasons where status = 'ACTIVE' limit 1;
+  if v_season_id is null then
+    raise exception '활성 시즌이 없어 주간 코인을 지급할 수 없습니다';
+  end if;
+
+  insert into public.wallets (user_id, season_id, balance, created_at, updated_at)
+  select id, v_season_id, 0, now(), now()
+  from public.users
+  where is_active = true
+  on conflict (user_id, season_id) do nothing;
+
+  with updated_wallets as (
+    update public.wallets w
+    set balance = w.balance + p_amount, updated_at = now()
+    from public.users u
+    where u.id = w.user_id
+      and u.is_active = true
+      and w.season_id = v_season_id
+    returning w.user_id, w.balance
+  ), inserted_transactions as (
+    insert into public.transactions (
+      user_id, type, amount, balance_after, reference_id,
+      description, season_id
+    )
+    select
+      user_id, 'WEEKLY_GRANT', p_amount, balance, null,
+      '주간 코인 지급', v_season_id
+    from updated_wallets
+    returning user_id
+  )
+  select count(*) into v_users_count from inserted_transactions;
+
+  return jsonb_build_object(
+    'success', true,
+    'users_count', v_users_count,
+    'total_distributed', v_users_count * p_amount
+  );
+exception
+  when others then
+    return jsonb_build_object('success', false, 'error', sqlerrm);
+end;
+$$;
+
+create or replace function public.admin_grant_coins(
+  p_user_id uuid,
+  p_amount numeric
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_season_id integer;
+  v_wallet public.wallets%rowtype;
+  v_new_balance numeric;
+begin
+  if not exists (
+    select 1 from public.users
+    where id = p_user_id and is_active = true
+  ) then
+    raise exception '비활성 회원에게는 코인을 지급할 수 없습니다';
+  end if;
+  if p_amount is null or p_amount <= 0 then
+    raise exception '지급 코인은 0보다 커야 합니다';
+  end if;
+  select id into v_season_id
+  from public.seasons where status = 'ACTIVE' limit 1;
+  if v_season_id is null then
+    raise exception '활성 시즌이 없습니다';
+  end if;
+
+  insert into public.wallets (user_id, season_id, balance, created_at, updated_at)
+  values (p_user_id, v_season_id, 0, now(), now())
+  on conflict (user_id, season_id) do nothing;
+
+  select * into v_wallet
+  from public.wallets
+  where user_id = p_user_id and season_id = v_season_id
+  for update;
+  v_new_balance := v_wallet.balance + p_amount;
+
+  update public.wallets
+  set balance = v_new_balance, updated_at = now()
+  where id = v_wallet.id;
+  insert into public.transactions (
+    user_id, type, amount, balance_after, reference_id,
+    description, season_id
+  )
+  values (
+    p_user_id, 'ADMIN_GRANT', p_amount, v_new_balance, null,
+    '관리자 코인 지급', v_season_id
+  );
+
+  return jsonb_build_object(
+    'success', true,
+    'user_id', p_user_id,
+    'granted_amount', p_amount,
+    'new_balance', v_new_balance
+  );
+exception
+  when others then
+    return jsonb_build_object('success', false, 'error', sqlerrm);
+end;
+$$;
+
+create or replace function public.activate_season(p_season_id integer)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_target public.seasons%rowtype;
+  v_previous_active_id integer;
+  v_open_market_count integer;
+  v_users_granted integer;
+  v_grant_amount numeric;
+begin
+  select * into v_target
+  from public.seasons
+  where id = p_season_id
+  for update;
+
+  if not found then
+    raise exception '활성화할 시즌을 찾을 수 없습니다';
+  end if;
+  if v_target.status <> 'DRAFT' then
+    raise exception 'DRAFT 시즌만 활성화할 수 있습니다';
+  end if;
+  if v_target.start_date >= v_target.end_date then
+    raise exception '시즌 시작일은 종료일보다 빨라야 합니다';
+  end if;
+
+  select id into v_previous_active_id
+  from public.seasons
+  where status = 'ACTIVE'
+  for update;
+
+  if v_previous_active_id is not null then
+    select count(*) into v_open_market_count
+    from public.markets
+    where season_id = v_previous_active_id
+      and status in ('OPEN', 'CLOSED');
+    if v_open_market_count > 0 then
+      raise exception '이전 시즌에 미정산 마켓 %개가 있어 새 시즌을 시작할 수 없습니다',
+        v_open_market_count;
+    end if;
+
+    update public.seasons
+    set status = 'ARCHIVED', updated_at = now()
+    where id = v_previous_active_id;
+  end if;
+
+  update public.seasons
+  set status = 'ACTIVE', updated_at = now()
+  where id = p_season_id;
+
+  select coalesce((value->>'amount')::numeric, 1000)
+  into v_grant_amount
+  from public.settings where key = 'member_initial_grant';
+  v_grant_amount := coalesce(v_grant_amount, 1000);
+
+  insert into public.wallets (user_id, season_id, balance, created_at, updated_at)
+  select id, p_season_id, v_grant_amount, now(), now()
+  from public.users
+  where is_active = true
+  on conflict (user_id, season_id) do nothing;
+
+  insert into public.transactions (
+    user_id, type, amount, balance_after, reference_id,
+    description, created_at, season_id
+  )
+  select
+    u.id, 'SEASON_GRANT', v_grant_amount, w.balance, p_season_id,
+    format('%s 시작 코인 지급', v_target.name), now(), p_season_id
+  from public.users u
+  join public.wallets w
+    on w.user_id = u.id
+   and w.season_id = p_season_id
+  where u.is_active = true
+    and not exists (
+      select 1
+      from public.transactions t
+      where t.user_id = u.id
+        and t.season_id = p_season_id
+        and t.type = 'SEASON_GRANT'
+    );
+  get diagnostics v_users_granted = row_count;
+
+  return jsonb_build_object(
+    'success', true,
+    'activated_season_id', p_season_id,
+    'archived_season_id', v_previous_active_id,
+    'users_granted', v_users_granted,
+    'grant_amount', v_grant_amount
+  );
+end;
+$$;
+
+revoke execute on function public.require_admin_operator(uuid, boolean)
+  from public, anon, authenticated;
+revoke execute on function public.admin_upsert_member(uuid, jsonb, boolean)
+  from public, anon, authenticated;
+revoke execute on function public.admin_bulk_upsert_members(uuid, jsonb)
+  from public, anon, authenticated;
+revoke execute on function public.admin_member_impact(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.admin_set_member_active(
+  uuid, uuid, boolean, boolean, text
+) from public, anon, authenticated;
+revoke execute on function public.admin_repair_member_wallet(uuid, uuid)
+  from public, anon, authenticated;
+
+grant execute on function public.require_admin_operator(uuid, boolean)
+  to service_role;
+grant execute on function public.admin_upsert_member(uuid, jsonb, boolean)
+  to service_role;
+grant execute on function public.admin_bulk_upsert_members(uuid, jsonb)
+  to service_role;
+grant execute on function public.admin_member_impact(uuid)
+  to service_role;
+grant execute on function public.admin_set_member_active(
+  uuid, uuid, boolean, boolean, text
+) to service_role;
+grant execute on function public.admin_repair_member_wallet(uuid, uuid)
+  to service_role;
+
+grant execute on function public.login(bigint, text)
+  to anon, authenticated, service_role;
+grant execute on function public.validate_user_session(uuid, integer)
+  to anon, authenticated, service_role;
+grant execute on function public.execute_buy_order(uuid, integer, text, numeric)
+  to anon, authenticated, service_role;
+grant execute on function public.execute_sell_order(uuid, integer, text, numeric)
+  to anon, authenticated, service_role;
+grant execute on function public.distribute_weekly_coins(numeric)
+  to service_role;
+grant execute on function public.admin_grant_coins(uuid, numeric)
+  to service_role;
+revoke execute on function public.activate_season(integer)
+  from public, anon, authenticated;
+grant execute on function public.activate_season(integer)
+  to service_role;

--- a/supabase/tests/37_member_management.sql
+++ b/supabase/tests/37_member_management.sql
@@ -1,0 +1,58 @@
+begin;
+
+select plan(8);
+
+select has_column('public', 'users', 'is_active', 'member active flag exists');
+select has_column(
+  'public',
+  'users',
+  'session_version',
+  'member session version exists'
+);
+select has_function(
+  'public',
+  'admin_upsert_member',
+  array['uuid', 'jsonb', 'boolean'],
+  'atomic member upsert exists'
+);
+select has_function(
+  'public',
+  'admin_set_member_active',
+  array['uuid', 'uuid', 'boolean', 'boolean', 'text'],
+  'member activation workflow exists'
+);
+select has_function(
+  'public',
+  'admin_repair_member_wallet',
+  array['uuid', 'uuid'],
+  'wallet repair workflow exists'
+);
+select isnt(
+  has_function_privilege(
+    'anon',
+    'public.admin_upsert_member(uuid,jsonb,boolean)',
+    'execute'
+  ),
+  true,
+  'anon cannot manage members'
+);
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.admin_upsert_member(uuid,jsonb,boolean)',
+    'execute'
+  ),
+  'service role can manage members'
+);
+select ok(
+  has_function_privilege(
+    'anon',
+    'public.validate_user_session(uuid,integer)',
+    'execute'
+  ),
+  'client can validate its local session version'
+);
+
+select * from finish();
+
+rollback;

--- a/tests/admin/issue-37.test.ts
+++ b/tests/admin/issue-37.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { createLocalServiceClient } from "@/tests/helpers/local-supabase";
+
+describe("issue #37 member lifecycle boundary", () => {
+  it("manages activation, password policy, and season wallets atomically", async () => {
+    const service = createLocalServiceClient();
+    const actorId = crypto.randomUUID();
+    const studentNumber = 2_099_999_999;
+    const { error: actorError } = await service.from("admin_operators").insert({
+      id: actorId,
+      username: `owner-${actorId.slice(0, 8)}`,
+      display_name: "테스트 OWNER",
+      role: "OWNER",
+      password_hash: "test-only",
+      must_change_password: false,
+    });
+    expect(actorError).toBeNull();
+
+    const { data, error } = await service
+      .from("users")
+      .select("id, is_active, session_version")
+      .limit(1);
+    expect(error).toBeNull();
+    expect(data?.[0]).toMatchObject({
+      is_active: true,
+      session_version: 1,
+    });
+
+    const existingUser = data?.[0];
+    expect(existingUser).toBeDefined();
+    if (!existingUser) return;
+
+    try {
+      const { data: deactivated, error: deactivateError } = await service.rpc(
+        "admin_set_member_active",
+        {
+          p_actor_id: actorId,
+          p_user_id: existingUser.id,
+          p_is_active: false,
+          p_confirm_open_positions: true,
+          p_reason: "테스트 비활성화",
+        },
+      );
+      expect(deactivateError).toBeNull();
+      expect(deactivated).toMatchObject({ success: true, is_active: false });
+
+      const { data: validation } = await service.rpc("validate_user_session", {
+        p_user_id: existingUser.id,
+        p_session_version: 1,
+      });
+      expect(validation).toMatchObject({ success: true, valid: false });
+
+      const { data: inactiveGrant } = await service.rpc("admin_grant_coins", {
+        p_user_id: existingUser.id,
+        p_amount: 10,
+      });
+      expect(inactiveGrant).toMatchObject({ success: false });
+      expect(String(inactiveGrant.error)).toContain("비활성 회원");
+
+      await service.rpc("admin_set_member_active", {
+        p_actor_id: actorId,
+        p_user_id: existingUser.id,
+        p_is_active: true,
+        p_confirm_open_positions: true,
+        p_reason: null,
+      });
+
+      const member = {
+        student_number: studentNumber,
+        username: "신규 회원",
+        phone_number: "010-7777-8888",
+        department: "컴퓨터공학과",
+        favorite_team_id: 1,
+      };
+      const { data: created, error: createError } = await service.rpc(
+        "admin_upsert_member",
+        {
+          p_actor_id: actorId,
+          p_member: member,
+          p_reset_password: false,
+        },
+      );
+      expect(createError, JSON.stringify(createError)).toBeNull();
+      expect(created).toMatchObject({
+        success: true,
+        action: "CREATE",
+        wallet_created: true,
+      });
+
+      const userId = String(created.user_id);
+      const { data: beforeUpdate } = await service
+        .from("users")
+        .select("password_hash, session_version")
+        .eq("id", userId)
+        .single();
+
+      await service.rpc("admin_upsert_member", {
+        p_actor_id: actorId,
+        p_member: { ...member, phone_number: "010-9999-0000" },
+        p_reset_password: false,
+      });
+      const { data: afterPhoneChange } = await service
+        .from("users")
+        .select("password_hash, session_version")
+        .eq("id", userId)
+        .single();
+      expect(afterPhoneChange?.password_hash).toBe(beforeUpdate?.password_hash);
+
+      await service.rpc("admin_upsert_member", {
+        p_actor_id: actorId,
+        p_member: { ...member, phone_number: "010-9999-0000" },
+        p_reset_password: true,
+      });
+      const { data: afterReset } = await service
+        .from("users")
+        .select("password_hash, password_changed, session_version")
+        .eq("id", userId)
+        .single();
+      expect(afterReset?.password_hash).not.toBe(beforeUpdate?.password_hash);
+      expect(afterReset?.password_changed).toBe(false);
+      expect(afterReset?.session_version).toBe(
+        Number(beforeUpdate?.session_version) + 1,
+      );
+
+      const { data: activeSeason } = await service
+        .from("seasons")
+        .select("id")
+        .eq("status", "ACTIVE")
+        .single();
+      await service
+        .from("wallets")
+        .delete()
+        .eq("user_id", userId)
+        .eq("season_id", activeSeason?.id);
+      const { data: repaired } = await service.rpc(
+        "admin_repair_member_wallet",
+        {
+          p_actor_id: actorId,
+          p_user_id: userId,
+        },
+      );
+      expect(repaired).toMatchObject({ success: true, created: true });
+    } finally {
+      await service
+        .from("users")
+        .update({ is_active: true })
+        .eq("id", existingUser.id);
+      await service.from("users").delete().eq("student_number", studentNumber);
+      await service.from("admin_operators").delete().eq("id", actorId);
+    }
+  });
+});

--- a/tests/admin/member-csv.test.ts
+++ b/tests/admin/member-csv.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  memberPreviewToCsv,
+  previewMemberCsv,
+} from "@/lib/admin/member-csv";
+
+describe("member CSV preview", () => {
+  it("classifies valid, duplicate, and invalid rows with Korean reasons", () => {
+    const preview = previewMemberCsv(
+      [
+        "student_number,username,phone_number,department,favorite_team,reset_password",
+        '2099999999,"CSV, 회원",01012341234,통계학과,1,false',
+        "2099999999,중복 회원,01012341234,통계학과,1,false",
+        "2099999998,오류 회원,123,통계학과,없는팀,false",
+      ].join("\n"),
+      [],
+      [{ id: 1, name: "KIA 타이거즈", short_name: "KIA" }],
+    );
+
+    expect(preview[0]).toMatchObject({
+      rowNumber: 2,
+      status: "CREATE",
+      member: { username: "CSV, 회원", favorite_team_id: 1 },
+    });
+    expect(preview[1].errors).toContain("CSV 안에 중복 학번이 있습니다.");
+    expect(preview[2].errors).toEqual(
+      expect.arrayContaining([
+        "전화번호 형식이 올바르지 않습니다.",
+        "선호팀을 찾을 수 없습니다.",
+      ]),
+    );
+    expect(memberPreviewToCsv(preview)).toContain("CSV 안에 중복 학번");
+  });
+});

--- a/tests/e2e/admin-ops.spec.ts
+++ b/tests/e2e/admin-ops.spec.ts
@@ -45,3 +45,106 @@ test("managed operator login protects the dashboard @issue-36", async ({
     fullPage: true,
   });
 });
+
+test("member lifecycle management is available @issue-37", async ({
+  browser,
+  page,
+}, testInfo) => {
+  test.setTimeout(60_000);
+  page.on("dialog", (dialog) => {
+    if (dialog.type() === "prompt") {
+      void dialog.accept("OwnerPass!234");
+    } else {
+      void dialog.accept();
+    }
+  });
+
+  await page.goto("/admin");
+  await page.getByPlaceholder("운영자 아이디").fill("owner");
+  await page.getByPlaceholder("운영자 비밀번호").fill("OwnerPass!234");
+  await page.getByRole("button", { name: "로그인" }).click();
+
+  const memberCard = page.getByRole("heading", { name: "회원 관리" }).locator("..");
+  await memberCard.getByRole("button", { name: "접속" }).click();
+  await expect(page.getByRole("heading", { name: "회원 관리" })).toBeVisible();
+
+  const userContext = await browser.newContext({
+    baseURL: "http://127.0.0.1:3000",
+  });
+  const userPage = await userContext.newPage();
+  await userPage.goto("/login");
+  await userPage.getByPlaceholder("학번 입력").fill("2024001");
+  await userPage.getByPlaceholder("비밀번호 입력").fill("01012345678");
+  await userPage.getByRole("button", { name: "로 그 인" }).click();
+  await expect(userPage).toHaveURL(/\/change-password/);
+  await userPage.getByPlaceholder("새 비밀번호").fill("UserPass!234");
+  await userPage.getByPlaceholder("비밀번호 확인").fill("UserPass!234");
+  await userPage.getByRole("button", { name: "변경 완료" }).click();
+  await expect(userPage).toHaveURL(/\/$/);
+
+  if (await memberCard.isVisible()) {
+    await memberCard.getByRole("button", { name: "접속" }).click();
+  }
+  await expect(page.getByRole("heading", { name: "회원 관리" })).toBeVisible();
+  await page.getByRole("spinbutton", { name: "학번" }).fill("2099999999");
+  await page.getByPlaceholder("이름", { exact: true }).fill("신규 회원");
+  await page.getByPlaceholder("전화번호").fill("01077778888");
+  await page.getByPlaceholder("학과", { exact: true }).fill("컴퓨터공학과");
+  await page.getByLabel("선호팀").selectOption("1");
+  await page.getByRole("button", { name: "저장", exact: true }).click();
+  await expect(page.getByText("회원 정보를 저장했습니다.")).toBeVisible();
+
+  const createdMember = page.getByTestId("member-2099999999");
+  await expect(createdMember.getByText("신규 회원 · 2099999999")).toBeVisible();
+  await expect(createdMember.getByText(/1,?000코인/)).toBeVisible();
+  await createdMember.getByRole("button", { name: "비활성화" }).click();
+  await expect(page.getByText("회원을 비활성화했습니다.")).toBeVisible();
+  await expect(
+    page.getByTestId("member-2099999999").getByText("비활성"),
+  ).toBeVisible();
+
+  await page
+    .getByTestId("member-2024001")
+    .getByRole("button", { name: "비활성화" })
+    .click();
+  await expect(page.getByText("회원을 비활성화했습니다.")).toBeVisible();
+  await userPage.goto("/history");
+  await expect(userPage).toHaveURL(/\/login/);
+  await userContext.close();
+
+  if (await memberCard.isVisible()) {
+    await memberCard.getByRole("button", { name: "접속" }).click();
+  }
+  await expect(page.getByRole("heading", { name: "회원 관리" })).toBeVisible();
+  const csv = [
+    "student_number,username,phone_number,department,favorite_team,reset_password",
+    "2099999998,CSV 회원,01012341234,통계학과,1,false",
+    "2099999997,오류 회원,123,통계학과,없는팀,false",
+  ].join("\n");
+  await expect(page.getByLabel("회원 CSV")).toBeEnabled();
+  await page.getByLabel("회원 CSV").setInputFiles({
+    name: "members.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(csv),
+  });
+  await expect(page.getByText("2행 · CREATE · CSV 회원")).toBeVisible();
+  await expect(page.getByText("3행 · ERROR")).toBeVisible();
+  await expect(page.getByText("전화번호 형식이 올바르지 않습니다.")).toBeVisible();
+  await page.getByRole("button", { name: "유효 행만 반영" }).click();
+  await expect(
+    page.getByText("1개 행을 반영했습니다. 오류 1개는 제외했습니다."),
+  ).toBeVisible();
+  await expect(page.getByTestId("member-2099999998")).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page
+    .getByRole("button", { name: "처리 결과 CSV 다운로드" })
+    .click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("member-import-result.csv");
+
+  await page.screenshot({
+    path: testInfo.outputPath("issue-37-member-management.png"),
+    fullPage: true,
+  });
+});

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,5 @@
+import { resetLocalDatabase } from "@/tests/helpers/local-supabase";
+
+export default function globalTeardown(): void {
+  resetLocalDatabase();
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./tests/setup.ts"],
     exclude: ["tests/e2e/**", "node_modules/**"],
+    fileParallelism: false,
     clearMocks: true,
     restoreMocks: true,
   },


### PR DESCRIPTION
## 요약
- 회원 검색/등록/수정/비활성화/재활성화와 활성 시즌 지갑 상태·복구 UI 추가
- 학번 기준 멱등 CSV 미리보기·유효 행 반영·한국어 오류·결과 다운로드 추가
- 비활성 회원 로그인/기존 세션/거래/관리자·주간·시즌 지급 차단
- 전화번호 변경과 비밀번호 초기화를 분리하고 모든 변경을 감사 로그에 기록

## 검증
- `npm run test:unit` (5 tests)
- `npm run test:db` (23 pgTAP assertions)
- `npx playwright test tests/e2e/admin-ops.spec.ts --grep "@issue-37"`
- `npm run typecheck`
- `npm run build:local`
- Playwright global teardown 후 로컬 사용자 수 3명 복원, port 3000 해제

## DB 안전
모든 마이그레이션·RPC·브라우저 검증은 `127.0.0.1` 로컬 Supabase에서만 수행했습니다. 운영 DB에는 어떤 수정도 하지 않았습니다.

## 의존성
- Stacked on #48 (`feat/admin-ops-36-auth`)

Closes #37