### PR TITLE
feat(admin): DRAFT 시즌 정책과 초기 지급 관리 추가

### DIFF
--- a/app/admin/SeasonManagement.tsx
+++ b/app/admin/SeasonManagement.tsx
@@ -1,552 +1,194 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { Input } from "@/components/ui/input";
+import { useCallback, useEffect, useState } from "react";
+import SeasonCard from "@/components/admin/SeasonCard";
+import SeasonConfirm, {
+  type SeasonConfirmation,
+} from "@/components/admin/SeasonConfirm";
+import SeasonEditor from "@/components/admin/SeasonEditor";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { useIsMobile } from "@/lib/hooks/useResponsive";
 import {
-  getActiveSeason,
-  listSeasons,
-  createSeason,
-  activateSeason,
-  endSeason,
-  type Season,
-  type SeasonStatus,
-} from "@/lib/api";
+  activateDraftSeason,
+  deleteDraftSeason,
+  endActiveSeason,
+  fetchManagedSeasons,
+  type ManagedSeason,
+} from "@/lib/admin/season-client";
 
-type Message = { type: "success" | "error"; text: string };
+type Props = Readonly<{
+  onReauthenticate: () => Promise<boolean>;
+}>;
 
-const formatPeriod = (start: string | null, end: string | null) => {
-  if (!start && !end) return "기간 미정";
-  return `${start ?? "?"} ~ ${end ?? "?"}`;
-};
+type Message = Readonly<{
+  type: "success" | "error";
+  text: string;
+}>;
 
-const statusBadgeClass = (status: SeasonStatus): string => {
-  switch (status) {
-    case "ACTIVE":
-      return "bg-green-100 text-green-800";
-    case "DRAFT":
-      return "bg-gray-100 text-gray-700";
-    case "ARCHIVED":
-      return "bg-zinc-200 text-zinc-600";
-    default:
-      return "bg-gray-100 text-gray-700";
-  }
-};
-
-const statusLabel = (status: SeasonStatus): string => {
-  switch (status) {
-    case "ACTIVE":
-      return "진행중";
-    case "DRAFT":
-      return "준비중";
-    case "ARCHIVED":
-      return "종료됨";
-    default:
-      return status;
-  }
-};
-
-interface ConfirmDialogState {
-  open: boolean;
-  title: string;
-  description: string;
-  confirmLabel: string;
-  variant: "default" | "destructive";
-  onConfirm: () => Promise<void> | void;
-}
-
-const EMPTY_CONFIRM: ConfirmDialogState = {
-  open: false,
-  title: "",
-  description: "",
-  confirmLabel: "확인",
-  variant: "default",
-  onConfirm: () => {},
-};
-
-export function SeasonManagement() {
-  const isMobile = useIsMobile();
-  const [seasons, setSeasons] = useState<Season[]>([]);
-  const [activeSeason, setActiveSeason] = useState<Season | null>(null);
-  const [loading, setLoading] = useState(true);
+export function SeasonManagement({ onReauthenticate }: Props) {
+  const [seasons, setSeasons] = useState<ManagedSeason[]>([]);
+  const [editing, setEditing] = useState<ManagedSeason | null | undefined>();
+  const [confirmation, setConfirmation] =
+    useState<SeasonConfirmation | null>(null);
   const [message, setMessage] = useState<Message | null>(null);
+  const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
 
-  const [createOpen, setCreateOpen] = useState(false);
-  const [formName, setFormName] = useState("");
-  const [formStartDate, setFormStartDate] = useState("");
-  const [formEndDate, setFormEndDate] = useState("");
-  const [formError, setFormError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-
-  const [confirm, setConfirm] = useState<ConfirmDialogState>(EMPTY_CONFIRM);
-
-  const fetchAll = async () => {
+  const refresh = useCallback(async () => {
+    setLoading(true);
     try {
-      setLoading(true);
-      const [list, active] = await Promise.all([
-        listSeasons(),
-        getActiveSeason(),
-      ]);
-      const sorted = [...list].sort((a, b) => b.id - a.id);
-      setSeasons(sorted);
-      setActiveSeason(active);
+      setSeasons(await fetchManagedSeasons());
     } catch (error) {
       setMessage({
         type: "error",
         text:
           error instanceof Error
             ? error.message
-            : "시즌 정보를 불러오지 못했습니다.",
+            : "시즌 목록을 불러오지 못했습니다.",
       });
     } finally {
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    void fetchAll();
   }, []);
 
-  const openCreate = () => {
-    setFormName("");
-    setFormStartDate("");
-    setFormEndDate("");
-    setFormError(null);
-    setCreateOpen(true);
-  };
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
 
-  const closeCreate = () => {
-    if (creating) return;
-    setCreateOpen(false);
-    setFormError(null);
-  };
-
-  const handleCreate = async (event: React.FormEvent) => {
-    event.preventDefault();
-    setFormError(null);
-
-    const trimmedName = formName.trim();
-    if (!trimmedName) {
-      setFormError("시즌 이름을 입력해 주세요.");
-      return;
-    }
-    if (!formStartDate || !formEndDate) {
-      setFormError("시작일과 종료일을 모두 입력해 주세요.");
-      return;
-    }
-    if (formStartDate >= formEndDate) {
-      setFormError("시작일은 종료일보다 빨라야 합니다.");
-      return;
-    }
-
-    setCreating(true);
+  async function runHighRisk(
+    operation: () => Promise<void>,
+    successText: string,
+  ) {
+    if (!(await onReauthenticate())) return;
+    setActionLoading(true);
     try {
-      await createSeason({
-        name: trimmedName,
-        startDate: formStartDate,
-        endDate: formEndDate,
-      });
-      setCreateOpen(false);
-      setMessage({
-        type: "success",
-        text: `'${trimmedName}' 시즌이 DRAFT 상태로 생성되었습니다.`,
-      });
-      await fetchAll();
+      await operation();
+      setConfirmation(null);
+      setMessage({ type: "success", text: successText });
+      await refresh();
     } catch (error) {
-      setFormError(
-        error instanceof Error
-          ? error.message
-          : "시즌 생성 중 오류가 발생했습니다."
-      );
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "시즌 작업에 실패했습니다.",
+      });
     } finally {
-      setCreating(false);
+      setActionLoading(false);
     }
-  };
+  }
 
-  const handleActivate = (season: Season) => {
-    setMessage(null);
-    setConfirm({
-      open: true,
-      title: "시즌 시작",
-      description: `'${season.name}' 시즌을 시작하시겠습니까?\n시작과 동시에 전체 유저에게 시즌 초기 코인이 지급되며,\n이전 시즌에 정산되지 않은 마켓이 있으면 활성화가 거부됩니다.`,
-      confirmLabel: "시즌 시작",
-      variant: "default",
-      onConfirm: async () => {
-        setActionLoading(true);
-        try {
-          const result = await activateSeason(season.id);
-          setMessage({
-            type: "success",
-            text: `'${season.name}' 시즌이 활성화되었습니다. ${result.usersGranted}명에게 초기 코인을 지급했습니다.`,
-          });
-          setConfirm(EMPTY_CONFIRM);
-          await fetchAll();
-        } catch (error) {
-          setMessage({
-            type: "error",
-            text:
-              error instanceof Error
-                ? error.message
-                : "시즌 활성화 중 오류가 발생했습니다.",
-          });
-          setConfirm(EMPTY_CONFIRM);
-        } finally {
-          setActionLoading(false);
-        }
-      },
-    });
-  };
-
-  const handleEnd = (season: Season) => {
-    setMessage(null);
-    setConfirm({
-      open: true,
-      title: "시즌 종료",
-      description: `'${season.name}' 시즌을 종료(ARCHIVED) 처리하시겠습니까?\n종료 후에는 다시 활성화할 수 없습니다.`,
-      confirmLabel: "시즌 종료",
+  function requestDelete(season: ManagedSeason) {
+    const impact = season.delete_impact;
+    setConfirmation({
+      title: "DRAFT 시즌 삭제",
+      description: `${season.name}을(를) 삭제합니다.\n연결 경기 ${impact?.linked_matches ?? 0}건 · 연결 마켓 ${impact?.linked_markets ?? 0}건`,
+      confirmLabel: "삭제",
       variant: "destructive",
-      onConfirm: async () => {
-        setActionLoading(true);
-        try {
-          await endSeason(season.id);
-          setMessage({
-            type: "success",
-            text: `'${season.name}' 시즌이 종료되었습니다.`,
-          });
-          setConfirm(EMPTY_CONFIRM);
-          await fetchAll();
-        } catch (error) {
-          setMessage({
-            type: "error",
-            text:
-              error instanceof Error
-                ? error.message
-                : "시즌 종료 중 오류가 발생했습니다.",
-          });
-          setConfirm(EMPTY_CONFIRM);
-        } finally {
-          setActionLoading(false);
-        }
-      },
+      onConfirm: () =>
+        runHighRisk(
+          () => deleteDraftSeason(season.id),
+          "DRAFT 시즌을 삭제했습니다.",
+        ),
     });
-  };
+  }
 
-  const closeConfirm = () => {
-    if (actionLoading) return;
-    setConfirm(EMPTY_CONFIRM);
-  };
+  function requestActivate(season: ManagedSeason) {
+    const preview = season.activation_preview;
+    setConfirmation({
+      title: "시즌 활성화",
+      description: `${season.name}을(를) 활성화합니다.\n대상 회원 ${preview?.eligible_members ?? 0}명 · 1인당 ${Number(preview?.initial_grant_amount ?? 0).toLocaleString()}코인 · 총 ${Number(preview?.total_planned_grant ?? 0).toLocaleString()}코인`,
+      confirmLabel: "활성화",
+      variant: "default",
+      onConfirm: () =>
+        runHighRisk(
+          () => activateDraftSeason(season.id),
+          "새 시즌을 활성화하고 초기 코인을 지급했습니다.",
+        ),
+    });
+  }
+
+  function requestEnd(season: ManagedSeason) {
+    setConfirmation({
+      title: "시즌 종료",
+      description: `${season.name}을(를) ARCHIVED 상태로 전환합니다.`,
+      confirmLabel: "종료",
+      variant: "destructive",
+      onConfirm: () =>
+        runHighRisk(
+          () => endActiveSeason(season.id),
+          "시즌을 종료했습니다.",
+        ),
+    });
+  }
+
+  const hasDraft = seasons.some((season) => season.status === "DRAFT");
 
   return (
-    <div className="space-y-6">
-      <div className="mb-2">
-        <h2
-          className={`font-bold text-black ${
-            isMobile ? "text-xl" : "text-2xl"
-          }`}
-        >
-          시즌 관리
-        </h2>
-        <p className="text-muted-foreground mt-2">
-          시즌을 생성하고 활성화/종료합니다. 활성 시즌이 바뀌면 전체 유저에게
-          초기 코인이 지급됩니다.
-        </p>
-      </div>
-
-      {message ? (
-        <div
-          className={`rounded-lg p-3 text-sm whitespace-pre-line ${
-            message.type === "success"
-              ? "bg-green-50 text-green-700"
-              : "bg-red-50 text-red-600"
-          }`}
-        >
-          {message.text}
-        </div>
-      ) : null}
-
-      <Card
-        className={`rounded-2xl border-tokhin-green/30 bg-tokhin-green/10 ${
-          isMobile ? "p-4" : "p-6"
-        }`}
-      >
-        {loading ? (
-          <p className="text-sm text-muted-foreground">
-            현재 활성 시즌을 불러오는 중...
+    <div className="space-y-5 pb-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold text-black">시즌 관리</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            DRAFT 기간과 초기 지급 정책을 확정한 뒤 활성화합니다.
           </p>
-        ) : activeSeason ? (
-          <div className="flex items-center justify-between gap-3 flex-wrap">
-            <div className="flex items-center gap-3">
-              <span className="relative flex h-3 w-3">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-tokhin-green opacity-60" />
-                <span className="relative inline-flex h-3 w-3 rounded-full bg-tokhin-green" />
-              </span>
-              <div>
-                <div className="text-xs font-light text-tokhin-green">
-                  현재 진행중인 시즌
-                </div>
-                <div className="text-lg font-bold text-black">
-                  {activeSeason.name}
-                </div>
-                <div className="text-sm font-normal text-muted-foreground">
-                  {formatPeriod(activeSeason.startDate, activeSeason.endDate)}
-                </div>
-              </div>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              className="h-12 rounded-lg border-red-300 text-red-600 hover:bg-red-50"
-              onClick={() => handleEnd(activeSeason)}
-            >
-              시즌 종료
-            </Button>
-          </div>
-        ) : (
-          <div className="flex items-center gap-3">
-            <span className="inline-flex h-3 w-3 rounded-full bg-gray-300" />
-            <div className="text-sm font-normal text-muted-foreground">
-              현재 활성화된 시즌이 없습니다. 아래에서 새 시즌을 생성하거나
-              DRAFT 시즌을 시작해 주세요.
-            </div>
-          </div>
-        )}
-      </Card>
-
-      <div className={isMobile ? "" : "flex justify-end"}>
+        </div>
         <Button
-          type="button"
-          onClick={openCreate}
-          className={`h-12 rounded-lg bg-tokhin-green text-white hover:bg-tokhin-green/90 ${
-            isMobile ? "w-full" : ""
-          }`}
+          className="h-12 shrink-0"
+          onClick={() => setEditing(null)}
+          disabled={hasDraft}
         >
-          + 새 시즌 생성
+          새 시즌
         </Button>
       </div>
 
-      {loading ? (
-        <Card className={`rounded-2xl ${isMobile ? "p-4" : "p-6"}`}>
-          <p className="text-sm text-muted-foreground">
-            시즌 목록을 불러오는 중...
-          </p>
-        </Card>
-      ) : seasons.length === 0 ? (
-        <Card className={`rounded-2xl ${isMobile ? "p-4" : "p-6"}`}>
-          <p className="text-sm text-muted-foreground">
-            등록된 시즌이 없습니다.
-          </p>
-        </Card>
-      ) : (
-        <div className="space-y-3">
-          {seasons.map((season) => {
-            const isActive = season.status === "ACTIVE";
-            const isDraft = season.status === "DRAFT";
-            const isArchived = season.status === "ARCHIVED";
-            return (
-              <Card
-                key={season.id}
-                className={`rounded-2xl ${isMobile ? "p-4" : "p-5"} ${
-                  isArchived ? "opacity-60" : ""
-                }`}
-              >
-                <div
-                  className={`${
-                    isMobile
-                      ? "space-y-3"
-                      : "flex items-center justify-between gap-3"
-                  }`}
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span
-                        className={`text-base font-bold ${
-                          isArchived ? "text-gray-500" : "text-black"
-                        }`}
-                      >
-                        {season.name}
-                      </span>
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusBadgeClass(
-                          season.status
-                        )}`}
-                      >
-                        {statusLabel(season.status)}
-                      </span>
-                    </div>
-                    <p className="mt-1 text-sm font-normal text-muted-foreground">
-                      {formatPeriod(season.startDate, season.endDate)}
-                    </p>
-                  </div>
+      {message ? (
+        <p
+          role={message.type === "error" ? "alert" : "status"}
+          className={`rounded-lg p-3 text-sm ${
+            message.type === "error"
+              ? "bg-red-50 text-red-600"
+              : "bg-green-50 text-green-700"
+          }`}
+        >
+          {message.text}
+        </p>
+      ) : null}
 
-                  <div
-                    className={`${
-                      isMobile ? "flex justify-end gap-2" : "flex gap-2"
-                    }`}
-                  >
-                    {isDraft ? (
-                      <Button
-                        type="button"
-                        onClick={() => handleActivate(season)}
-                        className="h-12 rounded-lg bg-tokhin-green text-white hover:bg-tokhin-green/90"
-                      >
-                        시즌 시작
-                      </Button>
-                    ) : null}
-                    {isActive ? (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={() => handleEnd(season)}
-                        className="h-12 rounded-lg border-red-300 text-red-600 hover:bg-red-50"
-                      >
-                        시즌 종료
-                      </Button>
-                    ) : null}
-                    {isArchived ? (
-                      <span className="text-xs font-light text-muted-foreground self-center">
-                        종료된 시즌
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
-              </Card>
-            );
-          })}
+      {loading ? (
+        <p className="text-sm text-muted-foreground">불러오는 중...</p>
+      ) : (
+        <div className="space-y-4">
+          {seasons.map((season) => (
+            <SeasonCard
+              key={season.id}
+              season={season}
+              onEdit={() => setEditing(season)}
+              onDelete={() => requestDelete(season)}
+              onActivate={() => requestActivate(season)}
+              onEnd={() => requestEnd(season)}
+            />
+          ))}
         </div>
       )}
 
-      {createOpen ? (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          role="dialog"
-          aria-modal="true"
-          onClick={closeCreate}
-        >
-          <Card
-            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <h3 className="text-lg font-bold text-black">새 시즌 생성</h3>
-            <p className="mt-1 text-sm font-light text-muted-foreground">
-              DRAFT 상태로 생성됩니다. 생성 후 &quot;시즌 시작&quot; 버튼을
-              눌러 활성화할 수 있습니다.
-            </p>
-
-            <form onSubmit={handleCreate} className="mt-5 space-y-4">
-              <div>
-                <Label htmlFor="season-name" className="mb-2 block">
-                  시즌 이름
-                </Label>
-                <Input
-                  id="season-name"
-                  placeholder="예: Season 3"
-                  value={formName}
-                  onChange={(event) => setFormName(event.target.value)}
-                  disabled={creating}
-                  className="text-black"
-                />
-              </div>
-              <div>
-                <Label htmlFor="season-start" className="mb-2 block">
-                  시작일
-                </Label>
-                <Input
-                  id="season-start"
-                  type="date"
-                  value={formStartDate}
-                  onChange={(event) => setFormStartDate(event.target.value)}
-                  disabled={creating}
-                  className="text-black"
-                />
-              </div>
-              <div>
-                <Label htmlFor="season-end" className="mb-2 block">
-                  종료일
-                </Label>
-                <Input
-                  id="season-end"
-                  type="date"
-                  value={formEndDate}
-                  onChange={(event) => setFormEndDate(event.target.value)}
-                  disabled={creating}
-                  className="text-black"
-                />
-              </div>
-
-              {formError ? (
-                <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
-                  {formError}
-                </div>
-              ) : null}
-
-              <div className="flex justify-end gap-2 pt-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={closeCreate}
-                  disabled={creating}
-                  className="h-12 rounded-lg"
-                >
-                  취소
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={creating}
-                  className="h-12 rounded-lg bg-tokhin-green text-white hover:bg-tokhin-green/90"
-                >
-                  {creating ? "생성 중..." : "생성"}
-                </Button>
-              </div>
-            </form>
-          </Card>
-        </div>
+      {editing !== undefined ? (
+        <SeasonEditor
+          season={editing}
+          onClose={() => setEditing(undefined)}
+          onSaved={async () => {
+            setEditing(undefined);
+            setMessage({
+              type: "success",
+              text: editing ? "DRAFT 시즌을 수정했습니다." : "DRAFT 시즌을 생성했습니다.",
+            });
+            await refresh();
+          }}
+        />
       ) : null}
-
-      {confirm.open ? (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          role="dialog"
-          aria-modal="true"
-          onClick={closeConfirm}
-        >
-          <Card
-            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <h3 className="text-lg font-bold text-black">{confirm.title}</h3>
-            <p className="mt-3 text-sm font-normal whitespace-pre-line text-muted-foreground">
-              {confirm.description}
-            </p>
-
-            <div className="mt-6 flex justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={closeConfirm}
-                disabled={actionLoading}
-                className="h-12 rounded-lg"
-              >
-                취소
-              </Button>
-              <Button
-                type="button"
-                onClick={() => void confirm.onConfirm()}
-                disabled={actionLoading}
-                className={`h-12 rounded-lg text-white ${
-                  confirm.variant === "destructive"
-                    ? "bg-red-600 hover:bg-red-700"
-                    : "bg-tokhin-green hover:bg-tokhin-green/90"
-                }`}
-              >
-                {actionLoading ? "처리 중..." : confirm.confirmLabel}
-              </Button>
-            </div>
-          </Card>
-        </div>
+      {confirmation ? (
+        <SeasonConfirm
+          confirmation={confirmation}
+          loading={actionLoading}
+          onClose={() => setConfirmation(null)}
+        />
       ) : null}
     </div>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2081,7 +2081,7 @@ function AdminDashboard({
         </div>
 
         {currentView === "seasons" ? (
-          <SeasonManagement />
+          <SeasonManagement onReauthenticate={controls.reauthenticate} />
         ) : currentView === "coins" ? (
           <CoinGrantManagement />
         ) : currentView === "password" ? (

--- a/app/api/admin/seasons/route.ts
+++ b/app/api/admin/seasons/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { recordAdminAudit } from "@/lib/admin/audit";
+import { requireAdminSession } from "@/lib/admin/authorization";
+import { AdminRequestError, adminErrorResponse } from "@/lib/admin/errors";
+import { createAdminServiceClient } from "@/lib/admin/service";
+
+const SeasonInputSchema = z.object({
+  name: z.string().trim().min(1, "시즌 이름을 입력해주세요.").max(100),
+  startDate: z.iso.date(),
+  endDate: z.iso.date(),
+  initialGrantAmount: z
+    .number()
+    .positive("초기 지급액은 0보다 커야 합니다."),
+});
+
+const MutationSchema = z.discriminatedUnion("action", [
+  SeasonInputSchema.extend({ action: z.literal("create") }),
+  SeasonInputSchema.extend({
+    action: z.literal("update"),
+    id: z.number().int().positive(),
+  }),
+  z.object({
+    action: z.enum(["delete", "activate", "end"]),
+    seasonId: z.number().int().positive(),
+  }),
+]);
+
+function databaseError(error: { message: string }): never {
+  throw new AdminRequestError(400, "SEASON_OPERATION_FAILED", error.message);
+}
+
+function assertRpcSuccess(data: unknown): void {
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "success" in data &&
+    data.success === false
+  ) {
+    const message =
+      "error" in data && typeof data.error === "string"
+        ? data.error
+        : "시즌 작업에 실패했습니다.";
+    throw new AdminRequestError(400, "SEASON_OPERATION_FAILED", message);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdminSession(request);
+    const service = createAdminServiceClient();
+    const { data, error } = await service
+      .from("seasons")
+      .select(
+        "id, name, start_date, end_date, status, initial_grant_amount, created_at",
+      )
+      .order("id", { ascending: false });
+    if (error) databaseError(error);
+
+    const seasons = await Promise.all(
+      (data ?? []).map(async (season) => {
+        if (season.status !== "DRAFT") {
+          return {
+            ...season,
+            delete_impact: null,
+            activation_preview: null,
+          };
+        }
+        const [deleteResult, activationResult] = await Promise.all([
+          service.rpc("get_draft_season_delete_impact", {
+            p_season_id: season.id,
+          }),
+          service.rpc("get_season_activation_preview", {
+            p_season_id: season.id,
+          }),
+        ]);
+        const previewError = deleteResult.error ?? activationResult.error;
+        if (previewError) databaseError(previewError);
+        return {
+          ...season,
+          delete_impact: deleteResult.data,
+          activation_preview: activationResult.data,
+        };
+      }),
+    );
+    return NextResponse.json({ seasons });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const parsed = MutationSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      throw new AdminRequestError(
+        400,
+        "INVALID_SEASON_INPUT",
+        parsed.error.issues[0]?.message ?? "시즌 입력값이 올바르지 않습니다.",
+      );
+    }
+    const input = parsed.data;
+    if (
+      "startDate" in input &&
+      input.startDate >= input.endDate
+    ) {
+      throw new AdminRequestError(
+        400,
+        "INVALID_SEASON_PERIOD",
+        "시작일은 종료일보다 빨라야 합니다.",
+      );
+    }
+    const highRisk = ["delete", "activate", "end"].includes(input.action);
+    const session = await requireAdminSession(
+      request,
+      "admin:mutate",
+      highRisk,
+    );
+    const service = createAdminServiceClient();
+
+    if (input.action === "create" || input.action === "update") {
+      const procedure =
+        input.action === "create"
+          ? "admin_create_draft_season"
+          : "admin_update_draft_season";
+      const args = {
+        p_operator_id: session.operator.id,
+        ...(input.action === "update" ? { p_season_id: input.id } : {}),
+        p_name: input.name,
+        p_start_date: input.startDate,
+        p_end_date: input.endDate,
+        p_initial_grant_amount: input.initialGrantAmount,
+      };
+      const { data, error } = await service.rpc(procedure, args);
+      if (error) databaseError(error);
+      return NextResponse.json({ season: data });
+    }
+
+    if (input.action === "delete") {
+      const { data, error } = await service.rpc(
+        "admin_delete_draft_season",
+        {
+          p_operator_id: session.operator.id,
+          p_season_id: input.seasonId,
+        },
+      );
+      if (error) databaseError(error);
+      return NextResponse.json({ result: data });
+    }
+
+    if (input.action === "activate") {
+      const { data, error } = await service.rpc("admin_activate_season", {
+        p_operator_id: session.operator.id,
+        p_season_id: input.seasonId,
+      });
+      if (error) databaseError(error);
+      return NextResponse.json({ result: data });
+    }
+
+    const { data: before } = await service
+      .from("seasons")
+      .select("*")
+      .eq("id", input.seasonId)
+      .single();
+    const { data, error } = await service.rpc("end_season", {
+      p_season_id: input.seasonId,
+    });
+    if (error) databaseError(error);
+    assertRpcSuccess(data);
+    await recordAdminAudit(request, {
+      operatorId: session.operator.id,
+      action: "SEASON_END",
+      targetType: "season",
+      targetId: String(input.seasonId),
+      beforeState: before,
+      afterState: data,
+      success: true,
+    });
+    return NextResponse.json({ result: data });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/components/admin/SeasonCard.tsx
+++ b/components/admin/SeasonCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type { ManagedSeason } from "@/lib/admin/season-client";
+
+type Props = Readonly<{
+  season: ManagedSeason;
+  onEdit: () => void;
+  onDelete: () => void;
+  onActivate: () => void;
+  onEnd: () => void;
+}>;
+
+const statusStyle = {
+  DRAFT: "bg-amber-100 text-amber-700",
+  ACTIVE: "bg-green-100 text-green-700",
+  ARCHIVED: "bg-gray-100 text-gray-600",
+} as const;
+
+function period(start: string | null, end: string | null) {
+  return `${start ?? "미정"} ~ ${end ?? "미정"}`;
+}
+
+export default function SeasonCard({
+  season,
+  onEdit,
+  onDelete,
+  onActivate,
+  onEnd,
+}: Props) {
+  const preview = season.activation_preview;
+  const impact = season.delete_impact;
+
+  return (
+    <Card className="rounded-2xl p-5" aria-label={`${season.name} 시즌`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-lg font-bold text-black">{season.name}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {period(season.start_date, season.end_date)}
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${statusStyle[season.status]}`}
+        >
+          {season.status}
+        </span>
+      </div>
+
+      <div className="mt-4 rounded-xl bg-slate-50 p-4 text-sm">
+        <p>
+          초기 지급액{" "}
+          <strong>{Number(season.initial_grant_amount).toLocaleString()}코인</strong>
+        </p>
+        {season.status === "DRAFT" ? (
+          <>
+            <p className="mt-1">
+              활성화 예정: {preview?.eligible_members ?? 0}명 · 총{" "}
+              {Number(preview?.total_planned_grant ?? 0).toLocaleString()}코인
+            </p>
+            <p className="mt-1">
+              삭제 영향: 경기 {impact?.linked_matches ?? 0}건 · 마켓{" "}
+              {impact?.linked_markets ?? 0}건
+            </p>
+          </>
+        ) : (
+          <p className="mt-2 text-muted-foreground">
+            ACTIVE와 ARCHIVED 시즌의 이름, 기간, 초기 지급액은 잠겨 있습니다.
+          </p>
+        )}
+      </div>
+
+      {season.status === "DRAFT" ? (
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          <Button variant="outline" className="h-12" onClick={onEdit}>
+            수정
+          </Button>
+          <Button
+            variant="outline"
+            className="h-12 border-red-200 text-red-600"
+            onClick={onDelete}
+          >
+            삭제
+          </Button>
+          <Button className="h-12" onClick={onActivate}>
+            시즌 시작
+          </Button>
+        </div>
+      ) : season.status === "ACTIVE" ? (
+        <Button
+          variant="outline"
+          className="mt-4 h-12 w-full border-red-200 text-red-600"
+          onClick={onEnd}
+        >
+          시즌 종료
+        </Button>
+      ) : null}
+    </Card>
+  );
+}

--- a/components/admin/SeasonConfirm.tsx
+++ b/components/admin/SeasonConfirm.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export type SeasonConfirmation = Readonly<{
+  title: string;
+  description: string;
+  confirmLabel: string;
+  variant: "default" | "destructive";
+  onConfirm: () => Promise<void>;
+}>;
+
+type Props = Readonly<{
+  confirmation: SeasonConfirmation;
+  loading: boolean;
+  onClose: () => void;
+}>;
+
+export default function SeasonConfirm({
+  confirmation,
+  loading,
+  onClose,
+}: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <Card
+        className="w-full max-w-md rounded-2xl bg-white p-6"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 className="text-lg font-bold text-black">{confirmation.title}</h3>
+        <p className="mt-3 whitespace-pre-line text-sm text-muted-foreground">
+          {confirmation.description}
+        </p>
+        <div className="mt-6 grid grid-cols-2 gap-2">
+          <Button
+            variant="outline"
+            className="h-12"
+            onClick={onClose}
+            disabled={loading}
+          >
+            취소
+          </Button>
+          <Button
+            className={`h-12 ${
+              confirmation.variant === "destructive"
+                ? "bg-red-600 hover:bg-red-700"
+                : ""
+            }`}
+            onClick={() => void confirmation.onConfirm()}
+            disabled={loading}
+          >
+            {loading ? "처리 중..." : confirmation.confirmLabel}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin/SeasonEditor.tsx
+++ b/components/admin/SeasonEditor.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  saveDraftSeason,
+  type ManagedSeason,
+} from "@/lib/admin/season-client";
+
+type Props = Readonly<{
+  season: ManagedSeason | null;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+}>;
+
+export default function SeasonEditor({ season, onClose, onSaved }: Props) {
+  const [name, setName] = useState(season?.name ?? "");
+  const [startDate, setStartDate] = useState(season?.start_date ?? "");
+  const [endDate, setEndDate] = useState(season?.end_date ?? "");
+  const [initialGrant, setInitialGrant] = useState(
+    String(season?.initial_grant_amount ?? 1000),
+  );
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const amount = Number(initialGrant);
+    if (startDate >= endDate) {
+      setError("시작일은 종료일보다 빨라야 합니다.");
+      return;
+    }
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setError("초기 지급액은 0보다 커야 합니다.");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      await saveDraftSeason({
+        id: season?.id,
+        name,
+        startDate,
+        endDate,
+        initialGrantAmount: amount,
+      });
+      await onSaved();
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "DRAFT 시즌 저장에 실패했습니다.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <Card
+        className="w-full max-w-md rounded-2xl bg-white p-6"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 className="text-lg font-bold text-black">
+          {season ? "DRAFT 시즌 수정" : "새 DRAFT 시즌"}
+        </h3>
+        <form className="mt-5 space-y-4" onSubmit={submit}>
+          <div>
+            <Label htmlFor="season-name">시즌 이름</Label>
+            <Input
+              id="season-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="season-start">시작일</Label>
+            <Input
+              id="season-start"
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="season-end">종료일</Label>
+            <Input
+              id="season-end"
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="season-initial-grant">초기 지급액</Label>
+            <Input
+              id="season-initial-grant"
+              type="number"
+              min="1"
+              value={initialGrant}
+              onChange={(event) => setInitialGrant(event.target.value)}
+              required
+            />
+          </div>
+          {error ? <p role="alert" className="text-sm text-red-600">{error}</p> : null}
+          <div className="grid grid-cols-2 gap-2">
+            <Button type="button" variant="outline" className="h-12" onClick={onClose}>
+              취소
+            </Button>
+            <Button className="h-12" disabled={saving}>
+              {saving ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/lib/admin/rpc-actions.ts
+++ b/lib/admin/rpc-actions.ts
@@ -4,18 +4,6 @@ const EmptyArgs = z.object({}).strict();
 
 export const AdminRpcRequestSchema = z.discriminatedUnion("action", [
   z.object({
-    action: z.literal("create_season"),
-    args: z.object({
-      p_name: z.string().min(1),
-      p_start_date: z.iso.date(),
-      p_end_date: z.iso.date(),
-    }),
-  }),
-  z.object({
-    action: z.literal("activate_season"),
-    args: z.object({ p_season_id: z.number().int().positive() }),
-  }),
-  z.object({
     action: z.literal("end_season"),
     args: z.object({ p_season_id: z.number().int().positive() }),
   }),
@@ -71,7 +59,6 @@ export const AdminRpcRequestSchema = z.discriminatedUnion("action", [
 export type AdminRpcRequest = z.infer<typeof AdminRpcRequestSchema>;
 
 const CRITICAL_ACTIONS = new Set<AdminRpcRequest["action"]>([
-  "activate_season",
   "end_season",
   "settle_market",
   "cancel_market",

--- a/lib/admin/season-client.ts
+++ b/lib/admin/season-client.ts
@@ -1,0 +1,88 @@
+export type ManagedSeasonStatus = "DRAFT" | "ACTIVE" | "ARCHIVED";
+
+export type DraftDeleteImpact = Readonly<{
+  season_id: number;
+  season_name: string;
+  linked_matches: number;
+  linked_markets: number;
+}>;
+
+export type ActivationPreview = Readonly<{
+  season_id: number;
+  season_name: string;
+  initial_grant_amount: number;
+  eligible_members: number;
+  total_planned_grant: number;
+}>;
+
+export type ManagedSeason = Readonly<{
+  id: number;
+  name: string;
+  start_date: string | null;
+  end_date: string | null;
+  status: ManagedSeasonStatus;
+  initial_grant_amount: number;
+  created_at: string;
+  delete_impact: DraftDeleteImpact | null;
+  activation_preview: ActivationPreview | null;
+}>;
+
+type SeasonInput = Readonly<{
+  id?: number;
+  name: string;
+  startDate: string;
+  endDate: string;
+  initialGrantAmount: number;
+}>;
+
+async function readJson<T>(response: Response): Promise<T> {
+  const body = (await response.json()) as T & { error?: string };
+  if (!response.ok) {
+    throw new Error(body.error ?? "시즌 관리 요청에 실패했습니다.");
+  }
+  return body;
+}
+
+async function mutate<T>(
+  action: string,
+  input: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch("/api/admin/seasons", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, ...input }),
+  });
+  return readJson<T>(response);
+}
+
+export async function fetchManagedSeasons(): Promise<ManagedSeason[]> {
+  const response = await fetch("/api/admin/seasons", {
+    credentials: "same-origin",
+    cache: "no-store",
+  });
+  return (await readJson<{ seasons: ManagedSeason[] }>(response)).seasons;
+}
+
+export async function saveDraftSeason(
+  input: SeasonInput,
+): Promise<ManagedSeason> {
+  return (
+    await mutate<{ season: ManagedSeason }>(
+      input.id ? "update" : "create",
+      input,
+    )
+  ).season;
+}
+
+export async function deleteDraftSeason(seasonId: number): Promise<void> {
+  await mutate("delete", { seasonId });
+}
+
+export async function activateDraftSeason(seasonId: number): Promise<void> {
+  await mutate("activate", { seasonId });
+}
+
+export async function endActiveSeason(seasonId: number): Promise<void> {
+  await mutate("end", { seasonId });
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -292,19 +292,6 @@ interface ListSeasonsRpcResponse {
   error?: string;
 }
 
-interface CreateSeasonRpcResponse {
-  success: boolean;
-  season?: SeasonRpcShape;
-  error?: string;
-}
-
-interface ActivateSeasonRpcResponse {
-  success: boolean;
-  season_id?: number | string;
-  users_granted?: number | string;
-  error?: string;
-}
-
 interface EndSeasonRpcResponse {
   success: boolean;
   season_id?: number | string;
@@ -921,58 +908,6 @@ export const listSeasons = async (): Promise<Season[]> => {
   }
 
   return (rpcResult.seasons ?? []).map(parseSeasonFromRpc);
-};
-
-export const createSeason = async (input: SeasonInput): Promise<Season> => {
-  if (!input.name || !input.name.trim()) {
-    throw new Error("시즌 이름이 비어 있습니다");
-  }
-
-  if (!input.startDate || !input.endDate) {
-    throw new Error("시즌 시작/종료 날짜가 비어 있습니다");
-  }
-
-  const data = await callAdminRpc("create_season", {
-    p_name: input.name,
-    p_start_date: input.startDate,
-    p_end_date: input.endDate,
-  });
-
-  const rpcResult = data as CreateSeasonRpcResponse | null;
-  if (!rpcResult?.success || !rpcResult.season) {
-    throw new Error(rpcResult?.error || "시즌 생성에 실패했습니다");
-  }
-
-  return parseSeasonFromRpc(rpcResult.season);
-};
-
-export const activateSeason = async (
-  seasonId: number
-): Promise<SeasonActivationResult> => {
-  if (!Number.isFinite(seasonId) || seasonId <= 0) {
-    throw new Error("유효하지 않은 시즌 ID입니다");
-  }
-
-  const data = await callAdminRpc("activate_season", {
-    p_season_id: seasonId,
-  });
-
-  const rpcResult = data as ActivateSeasonRpcResponse | null;
-  if (!rpcResult?.success) {
-    throw new Error(rpcResult?.error || "시즌 활성화에 실패했습니다");
-  }
-
-  const parsedSeasonId = Number(rpcResult.season_id ?? seasonId);
-  const usersGranted = Number(rpcResult.users_granted ?? 0);
-
-  if (!Number.isFinite(parsedSeasonId) || !Number.isFinite(usersGranted)) {
-    throw new Error("시즌 활성화 응답 형식이 올바르지 않습니다");
-  }
-
-  return {
-    seasonId: parsedSeasonId,
-    usersGranted,
-  };
 };
 
 export const endSeason = async (

--- a/supabase/migrations/20260802000039_draft_season_policies.sql
+++ b/supabase/migrations/20260802000039_draft_season_policies.sql
@@ -1,0 +1,471 @@
+-- Issue #39: governed DRAFT editing/deletion and configurable atomic grants.
+
+alter table public.seasons
+  add column if not exists initial_grant_amount numeric not null default 1000;
+
+alter table public.seasons
+  drop constraint if exists seasons_initial_grant_amount_check;
+
+alter table public.seasons
+  add constraint seasons_initial_grant_amount_check
+  check (initial_grant_amount > 0);
+
+create or replace function public.assert_valid_season_draft(
+  p_excluded_season_id integer,
+  p_name text,
+  p_start_date date,
+  p_end_date date,
+  p_initial_grant_amount numeric
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if btrim(coalesce(p_name, '')) = '' then
+    raise exception '시즌 이름을 입력해주세요';
+  end if;
+  if p_start_date is null or p_end_date is null then
+    raise exception '시작일과 종료일을 모두 입력해주세요';
+  end if;
+  if p_start_date >= p_end_date then
+    raise exception '시작일은 종료일보다 빨라야 합니다';
+  end if;
+  if p_initial_grant_amount is null or p_initial_grant_amount <= 0 then
+    raise exception '초기 지급액은 0보다 커야 합니다';
+  end if;
+  if exists (
+    select 1
+    from public.seasons s
+    where s.id is distinct from p_excluded_season_id
+      and s.start_date is not null
+      and s.end_date is not null
+      and daterange(s.start_date, s.end_date, '[]')
+        && daterange(p_start_date, p_end_date, '[]')
+  ) then
+    raise exception '다른 시즌 기간과 겹칩니다';
+  end if;
+end;
+$$;
+
+create or replace function public.admin_create_draft_season(
+  p_operator_id uuid,
+  p_name text,
+  p_start_date date,
+  p_end_date date,
+  p_initial_grant_amount numeric
+)
+returns public.seasons
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_season public.seasons;
+begin
+  perform public.assert_valid_season_draft(
+    null,
+    p_name,
+    p_start_date,
+    p_end_date,
+    p_initial_grant_amount
+  );
+
+  if exists (select 1 from public.seasons where status = 'DRAFT') then
+    raise exception '이미 DRAFT 시즌이 존재합니다';
+  end if;
+
+  insert into public.seasons (
+    name,
+    start_date,
+    end_date,
+    status,
+    initial_grant_amount
+  )
+  values (
+    btrim(p_name),
+    p_start_date,
+    p_end_date,
+    'DRAFT',
+    p_initial_grant_amount
+  )
+  returning * into v_season;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id, after_state, success
+  )
+  values (
+    p_operator_id,
+    'SEASON_DRAFT_CREATE',
+    'season',
+    v_season.id::text,
+    to_jsonb(v_season),
+    true
+  );
+
+  return v_season;
+end;
+$$;
+
+create or replace function public.admin_update_draft_season(
+  p_operator_id uuid,
+  p_season_id integer,
+  p_name text,
+  p_start_date date,
+  p_end_date date,
+  p_initial_grant_amount numeric
+)
+returns public.seasons
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_before public.seasons;
+  v_season public.seasons;
+begin
+  select *
+  into v_before
+  from public.seasons
+  where id = p_season_id
+  for update;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_before.status <> 'DRAFT' then
+    raise exception 'DRAFT 시즌만 수정할 수 있습니다';
+  end if;
+
+  perform public.assert_valid_season_draft(
+    p_season_id,
+    p_name,
+    p_start_date,
+    p_end_date,
+    p_initial_grant_amount
+  );
+
+  update public.seasons
+  set name = btrim(p_name),
+      start_date = p_start_date,
+      end_date = p_end_date,
+      initial_grant_amount = p_initial_grant_amount
+  where id = p_season_id
+  returning * into v_season;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_operator_id,
+    'SEASON_DRAFT_UPDATE',
+    'season',
+    v_season.id::text,
+    to_jsonb(v_before),
+    to_jsonb(v_season),
+    true
+  );
+
+  return v_season;
+end;
+$$;
+
+create or replace function public.get_draft_season_delete_impact(
+  p_season_id integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_season public.seasons;
+begin
+  select *
+  into v_season
+  from public.seasons
+  where id = p_season_id;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_season.status <> 'DRAFT' then
+    raise exception 'DRAFT 시즌만 삭제할 수 있습니다';
+  end if;
+
+  return jsonb_build_object(
+    'season_id', v_season.id,
+    'season_name', v_season.name,
+    'linked_matches', (
+      select count(distinct game_id)
+      from public.markets
+      where season_id = v_season.id
+    ),
+    'linked_markets', (
+      select count(*)
+      from public.markets
+      where season_id = v_season.id
+    )
+  );
+end;
+$$;
+
+create or replace function public.admin_delete_draft_season(
+  p_operator_id uuid,
+  p_season_id integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_season public.seasons;
+  v_impact jsonb;
+begin
+  select *
+  into v_season
+  from public.seasons
+  where id = p_season_id
+  for update;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_season.status <> 'DRAFT' then
+    raise exception 'DRAFT 시즌만 삭제할 수 있습니다';
+  end if;
+
+  v_impact := public.get_draft_season_delete_impact(p_season_id);
+  if (v_impact->>'linked_matches')::integer > 0
+    or (v_impact->>'linked_markets')::integer > 0 then
+    raise exception '연결된 경기 또는 마켓이 있어 DRAFT 시즌을 삭제할 수 없습니다';
+  end if;
+
+  delete from public.seasons where id = p_season_id;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_operator_id,
+    'SEASON_DRAFT_DELETE',
+    'season',
+    p_season_id::text,
+    to_jsonb(v_season),
+    v_impact,
+    true
+  );
+
+  return v_impact;
+end;
+$$;
+
+create or replace function public.get_season_activation_preview(
+  p_season_id integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_season public.seasons;
+  v_eligible_members integer;
+begin
+  select *
+  into v_season
+  from public.seasons
+  where id = p_season_id;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_season.status <> 'DRAFT' then
+    raise exception 'DRAFT 시즌만 활성화할 수 있습니다';
+  end if;
+
+  select count(*) into v_eligible_members from public.users;
+
+  return jsonb_build_object(
+    'season_id', v_season.id,
+    'season_name', v_season.name,
+    'initial_grant_amount', v_season.initial_grant_amount,
+    'eligible_members', v_eligible_members,
+    'total_planned_grant',
+      v_eligible_members * v_season.initial_grant_amount
+  );
+end;
+$$;
+
+create or replace function public.admin_activate_season(
+  p_operator_id uuid,
+  p_season_id integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_target public.seasons;
+  v_active public.seasons;
+  v_pending_count integer;
+  v_preview jsonb;
+  v_wallet_count integer;
+  v_grant_count integer;
+begin
+  select *
+  into v_target
+  from public.seasons
+  where id = p_season_id
+  for update;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_target.status <> 'DRAFT' then
+    raise exception 'DRAFT 시즌만 활성화할 수 있습니다';
+  end if;
+  if v_target.initial_grant_amount <= 0 then
+    raise exception '초기 지급액은 0보다 커야 합니다';
+  end if;
+
+  if exists (
+    select 1 from public.wallets where season_id = v_target.id
+  ) or exists (
+    select 1
+    from public.transactions
+    where season_id = v_target.id and type = 'SEASON_GRANT'
+  ) then
+    raise exception 'DRAFT 시즌에 초기 지급 데이터가 이미 존재합니다';
+  end if;
+
+  select *
+  into v_active
+  from public.seasons
+  where status = 'ACTIVE'
+  for update;
+
+  if found then
+    select count(*)
+    into v_pending_count
+    from public.markets
+    where season_id = v_active.id
+      and status in ('OPEN', 'CLOSED');
+
+    if v_pending_count > 0 then
+      raise exception '이전 시즌에 정산되지 않은 마켓이 %개 있습니다',
+        v_pending_count;
+    end if;
+  end if;
+
+  v_preview := public.get_season_activation_preview(v_target.id);
+
+  if v_active.id is not null then
+    update public.seasons
+    set status = 'ARCHIVED',
+        end_date = coalesce(end_date, v_target.start_date - 1)
+    where id = v_active.id;
+  end if;
+
+  update public.seasons
+  set status = 'ACTIVE'
+  where id = v_target.id;
+
+  insert into public.wallets (
+    user_id, season_id, balance, created_at, updated_at
+  )
+  select
+    u.id,
+    v_target.id,
+    v_target.initial_grant_amount,
+    now(),
+    now()
+  from public.users u;
+  get diagnostics v_wallet_count = row_count;
+
+  insert into public.transactions (
+    user_id,
+    season_id,
+    type,
+    amount,
+    balance_after,
+    description,
+    created_at
+  )
+  select
+    u.id,
+    v_target.id,
+    'SEASON_GRANT',
+    v_target.initial_grant_amount,
+    v_target.initial_grant_amount,
+    '시즌 시작 코인 지급',
+    now()
+  from public.users u;
+  get diagnostics v_grant_count = row_count;
+
+  if v_wallet_count <> v_grant_count then
+    raise exception '시즌 지갑과 지급 기록 수가 일치하지 않습니다';
+  end if;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_operator_id,
+    'SEASON_ACTIVATE',
+    'season',
+    v_target.id::text,
+    jsonb_build_object('target', to_jsonb(v_target), 'preview', v_preview),
+    jsonb_build_object(
+      'status', 'ACTIVE',
+      'wallets_created', v_wallet_count,
+      'grants_created', v_grant_count
+    ),
+    true
+  );
+
+  return v_preview || jsonb_build_object(
+    'success', true,
+    'users_granted', v_grant_count
+  );
+end;
+$$;
+
+revoke all on function public.assert_valid_season_draft(
+  integer, text, date, date, numeric
+) from public, anon, authenticated;
+revoke all on function public.admin_create_draft_season(
+  uuid, text, date, date, numeric
+) from public, anon, authenticated;
+revoke all on function public.admin_update_draft_season(
+  uuid, integer, text, date, date, numeric
+) from public, anon, authenticated;
+revoke all on function public.get_draft_season_delete_impact(integer)
+  from public, anon, authenticated;
+revoke all on function public.admin_delete_draft_season(uuid, integer)
+  from public, anon, authenticated;
+revoke all on function public.get_season_activation_preview(integer)
+  from public, anon, authenticated;
+revoke all on function public.admin_activate_season(uuid, integer)
+  from public, anon, authenticated;
+
+grant execute on function public.admin_create_draft_season(
+  uuid, text, date, date, numeric
+) to service_role;
+grant execute on function public.admin_update_draft_season(
+  uuid, integer, text, date, date, numeric
+) to service_role;
+grant execute on function public.get_draft_season_delete_impact(integer)
+  to service_role;
+grant execute on function public.admin_delete_draft_season(uuid, integer)
+  to service_role;
+grant execute on function public.get_season_activation_preview(integer)
+  to service_role;
+grant execute on function public.admin_activate_season(uuid, integer)
+  to service_role;

--- a/supabase/tests/39_draft_season_policies.sql
+++ b/supabase/tests/39_draft_season_policies.sql
@@ -1,0 +1,213 @@
+begin;
+
+select plan(21);
+
+select has_column(
+  'public',
+  'seasons',
+  'initial_grant_amount',
+  'seasons store configured initial grants'
+);
+select isnt(
+  has_function_privilege(
+    'anon',
+    'public.admin_update_draft_season(uuid,integer,text,date,date,numeric)',
+    'execute'
+  ),
+  true,
+  'anonymous users cannot edit draft seasons'
+);
+
+insert into public.seasons (
+  name, start_date, end_date, status, initial_grant_amount
+)
+values (
+  'Overlap Fixture',
+  date '2027-01-01',
+  date '2027-01-31',
+  'ARCHIVED',
+  1000
+);
+
+select throws_ok(
+  $$select public.admin_update_draft_season(
+    null, 2, 'Invalid Dates', date '2027-03-02', date '2027-03-01', 1500
+  )$$,
+  'P0001',
+  '시작일은 종료일보다 빨라야 합니다',
+  'draft updates reject reversed dates'
+);
+select throws_ok(
+  $$select public.admin_update_draft_season(
+    null, 2, 'Invalid Grant', date '2027-03-01', date '2027-03-31', 0
+  )$$,
+  'P0001',
+  '초기 지급액은 0보다 커야 합니다',
+  'draft updates reject non-positive grants'
+);
+select throws_ok(
+  $$select public.admin_update_draft_season(
+    null, 2, 'Overlap', date '2027-01-15', date '2027-02-15', 1500
+  )$$,
+  'P0001',
+  '다른 시즌 기간과 겹칩니다',
+  'draft updates reject overlapping periods'
+);
+select throws_ok(
+  $$select public.admin_update_draft_season(
+    null, 1, 'Active Edit', date '2026-03-28', date '2026-05-01', 1500
+  )$$,
+  'P0001',
+  'DRAFT 시즌만 수정할 수 있습니다',
+  'active seasons are immutable'
+);
+select throws_ok(
+  $$select public.admin_update_draft_season(
+    null, 0, 'Archived Edit', date '2026-01-01', date '2026-03-27', 1500
+  )$$,
+  'P0001',
+  'DRAFT 시즌만 수정할 수 있습니다',
+  'archived seasons are immutable'
+);
+select lives_ok(
+  $$select public.admin_update_draft_season(
+    null, 2, 'Season 2 Edited', date '2027-03-01', date '2027-03-31', 1500
+  )$$,
+  'draft metadata and grant amount can be updated'
+);
+
+insert into public.games (
+  id, game_date, game_time, home_team_id, away_team_id,
+  home_pitcher, away_pitcher, game_status
+)
+values (
+  9939, date '2027-03-10', '18:30', 1, 2, '', '', 'SCHEDULED'
+);
+insert into public.markets (game_id, b, season_id)
+values (9939, 200, 2);
+
+select is(
+  (
+    public.get_draft_season_delete_impact(2)->>'linked_matches'
+  )::integer,
+  1,
+  'deletion preview reports linked matches'
+);
+select is(
+  (
+    public.get_draft_season_delete_impact(2)->>'linked_markets'
+  )::integer,
+  1,
+  'deletion preview reports linked markets'
+);
+select throws_ok(
+  $$select public.admin_delete_draft_season(null, 2)$$,
+  'P0001',
+  '연결된 경기 또는 마켓이 있어 DRAFT 시즌을 삭제할 수 없습니다',
+  'linked draft seasons cannot be deleted'
+);
+select throws_ok(
+  $$select public.admin_delete_draft_season(null, 1)$$,
+  'P0001',
+  'DRAFT 시즌만 삭제할 수 있습니다',
+  'active seasons cannot be deleted'
+);
+
+delete from public.markets where game_id = 9939;
+select lives_ok(
+  $$select public.admin_delete_draft_season(null, 2)$$,
+  'unlinked draft seasons can be deleted'
+);
+
+select throws_ok(
+  $$select public.admin_create_draft_season(
+    null, 'Overlap Create', date '2027-01-10', date '2027-01-20', 1500
+  )$$,
+  'P0001',
+  '다른 시즌 기간과 겹칩니다',
+  'draft creation rejects overlapping periods'
+);
+
+select lives_ok(
+  $$select public.admin_create_draft_season(
+    null, 'Season 3', date '2027-02-01', date '2027-02-28', 1500
+  )$$,
+  'operators can create a configured draft season'
+);
+select is(
+  (
+    public.get_season_activation_preview(
+      (select id from public.seasons where name = 'Season 3')
+    )->>'eligible_members'
+  )::integer,
+  3,
+  'activation preview reports eligible members'
+);
+select is(
+  (
+    public.get_season_activation_preview(
+      (select id from public.seasons where name = 'Season 3')
+    )->>'total_planned_grant'
+  )::numeric,
+  4500::numeric,
+  'activation preview reports total configured grant'
+);
+
+update public.markets
+set status = 'CANCELED'
+where season_id = 1;
+
+select is(
+  (
+    public.admin_activate_season(
+      null,
+      (select id from public.seasons where name = 'Season 3')
+    )->>'users_granted'
+  )::integer,
+  3,
+  'activation grants every eligible member'
+);
+select is(
+  (
+    select count(*)::integer
+    from public.wallets
+    where season_id = (
+      select id from public.seasons where name = 'Season 3'
+    )
+      and balance = 1500
+  ),
+  3,
+  'activation creates configured wallets'
+);
+select is(
+  (
+    select count(*)::integer
+    from public.transactions
+    where season_id = (
+      select id from public.seasons where name = 'Season 3'
+    )
+      and type = 'SEASON_GRANT'
+      and amount = 1500
+      and balance_after = 1500
+  ),
+  3,
+  'activation creates matching grant records'
+);
+select is(
+  (
+    select count(distinct action)::integer
+    from public.admin_audit_logs
+    where action in (
+      'SEASON_DRAFT_CREATE',
+      'SEASON_DRAFT_UPDATE',
+      'SEASON_DRAFT_DELETE',
+      'SEASON_ACTIVATE'
+    )
+  ),
+  4,
+  'all draft mutations and activation are audited'
+);
+
+select * from finish();
+
+rollback;

--- a/tests/admin/issue-39.test.ts
+++ b/tests/admin/issue-39.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { createLocalServiceClient } from "@/tests/helpers/local-supabase";
+
+describe("issue #39 draft season policies", () => {
+  it("stores configurable initial grants and governed draft operations", async () => {
+    const service = createLocalServiceClient();
+    const seasons = await service
+      .from("seasons")
+      .select("id, status, initial_grant_amount")
+      .limit(1);
+    const updateRpc = await service.rpc("admin_update_draft_season", {
+      p_operator_id: null,
+      p_season_id: 2,
+      p_name: "Season 2",
+      p_start_date: "2026-05-19",
+      p_end_date: "2026-06-21",
+      p_initial_grant_amount: 1000,
+    });
+
+    expect(seasons.error).toBeNull();
+    expect(updateRpc.error).toBeNull();
+  });
+});

--- a/tests/e2e/admin-ops.spec.ts
+++ b/tests/e2e/admin-ops.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { createLocalServiceClient } from "@/tests/helpers/local-supabase";
 
 test("managed operator login protects the dashboard @issue-36", async ({
   page,
@@ -42,6 +43,109 @@ test("managed operator login protects the dashboard @issue-36", async ({
   await expect(page.getByText("운영자 추가").first()).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("issue-36-owner-dashboard.png"),
+    fullPage: true,
+  });
+});
+
+test("draft season policy management is available @issue-39", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/admin");
+  await page.getByPlaceholder("운영자 아이디").fill("owner");
+  await page.getByPlaceholder("운영자 비밀번호").fill("OwnerPass!234");
+  await page.getByRole("button", { name: "로그인" }).click();
+
+  const seasonCard = page
+    .getByRole("heading", { name: "시즌 관리" })
+    .locator("..");
+  await seasonCard.getByRole("button", { name: "접속" }).click();
+  await expect(page.getByText("초기 지급액 1,000코인").first()).toBeVisible();
+  await expect(
+    page.getByText(
+      "ACTIVE와 ARCHIVED 시즌의 이름, 기간, 초기 지급액은 잠겨 있습니다.",
+    ).first(),
+  ).toBeVisible();
+
+  page.on("dialog", async (dialog) => {
+    await dialog.accept("OwnerPass!234");
+  });
+
+  let draftCard = page.getByLabel("Season 2 시즌");
+  await draftCard.getByRole("button", { name: "수정" }).click();
+  await page.getByLabel("시즌 이름").fill("Season 2 Edited");
+  await page.getByLabel("초기 지급액").fill("1500");
+  await page.getByRole("button", { name: "저장" }).click();
+  await expect(page.getByText("DRAFT 시즌을 수정했습니다.")).toBeVisible();
+
+  draftCard = page.getByLabel("Season 2 Edited 시즌");
+  await expect(draftCard.getByText("활성화 예정: 3명 · 총 4,500코인")).toBeVisible();
+  await draftCard.getByRole("button", { name: "삭제" }).click();
+  const deleteDialog = page.getByRole("dialog");
+  await expect(deleteDialog.getByText(/연결 경기 0건 · 연결 마켓 0건/)).toBeVisible();
+  await deleteDialog.getByRole("button", { name: "삭제" }).click();
+  await expect(page.getByText("DRAFT 시즌을 삭제했습니다.")).toBeVisible();
+
+  await page.getByRole("button", { name: "새 시즌" }).click();
+  await page.getByLabel("시즌 이름").fill("UI Season");
+  await page.getByLabel("시작일").fill("2027-04-10");
+  await page.getByLabel("종료일").fill("2027-04-01");
+  await page.getByLabel("초기 지급액").fill("1500");
+  await page.getByRole("button", { name: "저장" }).click();
+  await expect(
+    page.getByText("시작일은 종료일보다 빨라야 합니다."),
+  ).toBeVisible();
+  await page.getByLabel("시작일").fill("2027-04-01");
+  await page.getByLabel("종료일").fill("2027-04-30");
+  await page.getByRole("button", { name: "저장" }).click();
+  await expect(page.getByText("DRAFT 시즌을 생성했습니다.")).toBeVisible();
+
+  const uiSeason = page.getByLabel("UI Season 시즌");
+  await expect(uiSeason.getByText("활성화 예정: 3명 · 총 4,500코인")).toBeVisible();
+
+  const service = createLocalServiceClient();
+  const marketCleanup = await service
+    .from("markets")
+    .update({ status: "CANCELED" })
+    .eq("season_id", 1);
+  expect(marketCleanup.error).toBeNull();
+
+  await uiSeason.getByRole("button", { name: "시즌 시작" }).click();
+  const activateDialog = page.getByRole("dialog");
+  await expect(
+    activateDialog.getByText(/대상 회원 3명 · 1인당 1,500코인 · 총 4,500코인/),
+  ).toBeVisible();
+  await activateDialog.getByRole("button", { name: "활성화" }).click();
+  await expect(
+    page.getByText("새 시즌을 활성화하고 초기 코인을 지급했습니다."),
+  ).toBeVisible();
+  await expect(
+    page.getByLabel("UI Season 시즌").getByText("ACTIVE", { exact: true }),
+  ).toBeVisible();
+
+  const activated = await service
+    .from("seasons")
+    .select("id")
+    .eq("name", "UI Season")
+    .single();
+  expect(activated.error).toBeNull();
+  const [wallets, grants] = await Promise.all([
+    service
+      .from("wallets")
+      .select("id", { count: "exact", head: true })
+      .eq("season_id", activated.data!.id)
+      .eq("balance", 1500),
+    service
+      .from("transactions")
+      .select("id", { count: "exact", head: true })
+      .eq("season_id", activated.data!.id)
+      .eq("type", "SEASON_GRANT")
+      .eq("amount", 1500),
+  ]);
+  expect(wallets.count).toBe(3);
+  expect(grants.count).toBe(3);
+
+  await page.screenshot({
+    path: testInfo.outputPath("issue-39-draft-season-policy.png"),
     fullPage: true,
   });
 });


### PR DESCRIPTION
## 요약
- DRAFT 시즌 이름·기간·초기 지급액 생성/수정과 겹침·역전·0 이하 검증 추가
- 삭제 전 연결 경기/마켓 영향 표시 및 연결 데이터가 있는 DRAFT 삭제 차단
- 활성화 전 대상 회원 수·1인 지급액·총 지급액 미리보기 추가
- 설정 금액으로 지갑과 SEASON_GRANT를 한 트랜잭션에서 생성하고 시즌 변경을 감사 기록
- ACTIVE/ARCHIVED 필드 잠금 안내와 서버 우회 수정/삭제 차단

## 검증
- `npm run test:unit` (4 tests)
- `npm run test:db` (36 pgTAP assertions)
- `npx playwright test tests/e2e/admin-ops.spec.ts --grep "@issue-39"`
- `npm run typecheck`
- `npm run build:local`
- 활성화 후 1,500코인 지갑 3개와 대응 SEASON_GRANT 3개 확인
- 최종 로컬 DB 3 users / 1 DRAFT / 1 ACTIVE 복원, port 3000 해제

## DB 안전
모든 마이그레이션·RPC·브라우저 검증은 `127.0.0.1` 로컬 Supabase에서만 수행했습니다. 운영 DB에는 어떤 수정도 하지 않았습니다.

## 의존성
- Stacked on #48 (`feat/admin-ops-36-auth`)
- #37/#38과 독립적인 브랜치입니다.

Closes #39