### PR TITLE
feat(admin): 시즌 종료 준비와 일괄 처리 콘솔 추가

### DIFF
--- a/app/admin/SeasonManagement.tsx
+++ b/app/admin/SeasonManagement.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import SeasonCard from "@/components/admin/SeasonCard";
+import SeasonCloseConsole from "@/components/admin/SeasonCloseConsole";
 import SeasonConfirm, {
   type SeasonConfirmation,
 } from "@/components/admin/SeasonConfirm";
@@ -10,7 +11,6 @@ import { Button } from "@/components/ui/button";
 import {
   activateDraftSeason,
   deleteDraftSeason,
-  endActiveSeason,
   fetchManagedSeasons,
   type ManagedSeason,
 } from "@/lib/admin/season-client";
@@ -105,21 +105,8 @@ export function SeasonManagement({ onReauthenticate }: Props) {
     });
   }
 
-  function requestEnd(season: ManagedSeason) {
-    setConfirmation({
-      title: "시즌 종료",
-      description: `${season.name}을(를) ARCHIVED 상태로 전환합니다.`,
-      confirmLabel: "종료",
-      variant: "destructive",
-      onConfirm: () =>
-        runHighRisk(
-          () => endActiveSeason(season.id),
-          "시즌을 종료했습니다.",
-        ),
-    });
-  }
-
   const hasDraft = seasons.some((season) => season.status === "DRAFT");
+  const activeSeason = seasons.find((season) => season.status === "ACTIVE");
 
   return (
     <div className="space-y-5 pb-4">
@@ -156,6 +143,13 @@ export function SeasonManagement({ onReauthenticate }: Props) {
         <p className="text-sm text-muted-foreground">불러오는 중...</p>
       ) : (
         <div className="space-y-4">
+          {activeSeason ? (
+            <SeasonCloseConsole
+              seasonId={activeSeason.id}
+              onReauthenticate={onReauthenticate}
+              onSeasonClosed={refresh}
+            />
+          ) : null}
           {seasons.map((season) => (
             <SeasonCard
               key={season.id}
@@ -163,7 +157,6 @@ export function SeasonManagement({ onReauthenticate }: Props) {
               onEdit={() => setEditing(season)}
               onDelete={() => requestDelete(season)}
               onActivate={() => requestActivate(season)}
-              onEnd={() => requestEnd(season)}
             />
           ))}
         </div>

--- a/app/api/admin/season-close/route.ts
+++ b/app/api/admin/season-close/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdminSession } from "@/lib/admin/authorization";
+import { AdminRequestError, adminErrorResponse } from "@/lib/admin/errors";
+import { createAdminServiceClient } from "@/lib/admin/service";
+
+const ProcessSchema = z.object({
+  action: z.literal("process"),
+  seasonId: z.number().int().positive(),
+  items: z
+    .array(
+      z.object({
+        marketId: z.number().int().positive(),
+        action: z.enum(["CLOSE", "SETTLE", "CANCEL"]),
+        result: z.enum(["HOME", "AWAY", "DRAW"]).optional(),
+      }),
+    )
+    .min(1)
+    .max(1000),
+});
+
+const MutationSchema = z.discriminatedUnion("action", [
+  ProcessSchema,
+  z.object({
+    action: z.literal("close"),
+    seasonId: z.number().int().positive(),
+  }),
+]);
+
+function databaseError(error: { message: string }): never {
+  throw new AdminRequestError(400, "SEASON_CLOSE_FAILED", error.message);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdminSession(request);
+    const seasonId = Number(request.nextUrl.searchParams.get("seasonId"));
+    const page = Number(request.nextUrl.searchParams.get("page") ?? 1);
+    const pageSize = Number(request.nextUrl.searchParams.get("pageSize") ?? 2);
+    if (!Number.isInteger(seasonId) || seasonId <= 0) {
+      throw new AdminRequestError(
+        400,
+        "INVALID_SEASON_ID",
+        "유효한 시즌을 선택해주세요.",
+      );
+    }
+    const { data, error } = await createAdminServiceClient().rpc(
+      "get_season_close_readiness",
+      {
+        p_season_id: seasonId,
+        p_page: page,
+        p_page_size: pageSize,
+      },
+    );
+    if (error) databaseError(error);
+    return NextResponse.json({ readiness: data });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const parsed = MutationSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      throw new AdminRequestError(
+        400,
+        "INVALID_CLOSE_INPUT",
+        parsed.error.issues[0]?.message ?? "처리 입력값이 올바르지 않습니다.",
+      );
+    }
+    const input = parsed.data;
+    const session = await requireAdminSession(request, "admin:mutate", true);
+    const service = createAdminServiceClient();
+
+    if (input.action === "process") {
+      const { data, error } = await service.rpc(
+        "admin_process_season_markets",
+        {
+          p_operator_id: session.operator.id,
+          p_season_id: input.seasonId,
+          p_items: input.items.map((item) => ({
+            market_id: item.marketId,
+            action: item.action,
+            result: item.result ?? null,
+          })),
+        },
+      );
+      if (error) databaseError(error);
+      return NextResponse.json({
+        results: data?.results ?? [],
+        readiness: data?.readiness,
+      });
+    }
+
+    const { data, error } = await service.rpc("admin_close_ready_season", {
+      p_operator_id: session.operator.id,
+      p_season_id: input.seasonId,
+    });
+    if (error) databaseError(error);
+    return NextResponse.json({ result: data });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/components/admin/SeasonBlockerCard.tsx
+++ b/components/admin/SeasonBlockerCard.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import type {
+  CloseAction,
+  CloseReadinessItem,
+  SettlementResult,
+} from "@/lib/admin/season-close-client";
+
+export type BlockerSelection = Readonly<{
+  selected: boolean;
+  action: CloseAction;
+  result?: SettlementResult;
+}>;
+
+type Props = Readonly<{
+  item: CloseReadinessItem;
+  selection: BlockerSelection;
+  onChange: (next: BlockerSelection) => void;
+}>;
+
+const classificationLabel = {
+  AUTO_DECIDABLE: "자동 판정",
+  MANUAL_REVIEW: "수동 검토",
+  CANCELLATION_RECOMMENDED: "취소 권장",
+} as const;
+
+export function defaultBlockerSelection(
+  item: CloseReadinessItem,
+): BlockerSelection {
+  const action: CloseAction =
+    item.classification === "CANCELLATION_RECOMMENDED"
+      ? "CANCEL"
+      : item.classification === "AUTO_DECIDABLE"
+        ? "SETTLE"
+        : item.market_status === "OPEN"
+          ? "CLOSE"
+          : "CANCEL";
+  return {
+    selected: false,
+    action,
+    result: item.proposed_result ?? undefined,
+  };
+}
+
+export default function SeasonBlockerCard({
+  item,
+  selection,
+  onChange,
+}: Props) {
+  const score =
+    item.home_score === null || item.away_score === null
+      ? "-"
+      : `${item.home_score} : ${item.away_score}`;
+
+  return (
+    <Card className="rounded-2xl p-4" aria-label={`마켓 ${item.market_id}`}>
+      <div className="flex items-start gap-3">
+        <input
+          aria-label={`마켓 ${item.market_id} 선택`}
+          type="checkbox"
+          checked={selection.selected}
+          onChange={(event) =>
+            onChange({ ...selection, selected: event.target.checked })
+          }
+          className="mt-1 h-5 w-5"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-bold text-black">마켓 #{item.market_id}</p>
+            <span className="rounded-full bg-slate-100 px-2 py-1 text-xs">
+              {classificationLabel[item.classification]}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {item.game_date} · 경기 {item.game_status} · 마켓 {item.market_status}
+          </p>
+          <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+            <div className="rounded-lg bg-slate-50 p-2">
+              <p className="text-muted-foreground">스코어</p>
+              <p className="mt-1 font-semibold">{score}</p>
+            </div>
+            <div className="rounded-lg bg-slate-50 p-2">
+              <p className="text-muted-foreground">보유자</p>
+              <p className="mt-1 font-semibold">{item.position_holder_count}명</p>
+            </div>
+            <div className="rounded-lg bg-slate-50 p-2">
+              <p className="text-muted-foreground">제안</p>
+              <p className="mt-1 font-semibold">{item.proposed_result ?? "-"}</p>
+            </div>
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            예상 지급 {Number(item.estimated_payout).toLocaleString()} · 예상 환급{" "}
+            {Number(item.estimated_refund).toLocaleString()} 코인
+          </p>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <select
+              aria-label={`마켓 ${item.market_id} 작업`}
+              value={selection.action}
+              onChange={(event) =>
+                onChange({
+                  ...selection,
+                  action: event.target.value as CloseAction,
+                })
+              }
+              className="h-11 rounded-lg border bg-white px-2 text-sm"
+            >
+              {item.eligible_actions.map((action) => (
+                <option key={action} value={action}>
+                  {action}
+                </option>
+              ))}
+            </select>
+            <select
+              aria-label={`마켓 ${item.market_id} 정산 결과`}
+              value={selection.result ?? ""}
+              onChange={(event) =>
+                onChange({
+                  ...selection,
+                  result: (event.target.value || undefined) as
+                    | SettlementResult
+                    | undefined,
+                })
+              }
+              disabled={selection.action !== "SETTLE"}
+              className="h-11 rounded-lg border bg-white px-2 text-sm disabled:bg-slate-100"
+            >
+              <option value="">결과 선택</option>
+              <option value="HOME">HOME</option>
+              <option value="AWAY">AWAY</option>
+              <option value="DRAW">DRAW</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/admin/SeasonCard.tsx
+++ b/components/admin/SeasonCard.tsx
@@ -9,7 +9,6 @@ type Props = Readonly<{
   onEdit: () => void;
   onDelete: () => void;
   onActivate: () => void;
-  onEnd: () => void;
 }>;
 
 const statusStyle = {
@@ -27,7 +26,6 @@ export default function SeasonCard({
   onEdit,
   onDelete,
   onActivate,
-  onEnd,
 }: Props) {
   const preview = season.activation_preview;
   const impact = season.delete_impact;
@@ -87,14 +85,6 @@ export default function SeasonCard({
             시즌 시작
           </Button>
         </div>
-      ) : season.status === "ACTIVE" ? (
-        <Button
-          variant="outline"
-          className="mt-4 h-12 w-full border-red-200 text-red-600"
-          onClick={onEnd}
-        >
-          시즌 종료
-        </Button>
       ) : null}
     </Card>
   );

--- a/components/admin/SeasonCloseConsole.tsx
+++ b/components/admin/SeasonCloseConsole.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import SeasonBlockerCard, {
+  defaultBlockerSelection,
+  type BlockerSelection,
+} from "@/components/admin/SeasonBlockerCard";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  closeReadySeason,
+  downloadSeasonCloseCsv,
+  fetchSeasonCloseReadiness,
+  processSeasonMarkets,
+  type CloseReadinessItem,
+  type CloseProcessResult,
+  type SeasonCloseReadiness,
+} from "@/lib/admin/season-close-client";
+
+type Props = Readonly<{
+  seasonId: number;
+  onReauthenticate: () => Promise<boolean>;
+  onSeasonClosed: () => Promise<void>;
+}>;
+
+export default function SeasonCloseConsole({
+  seasonId,
+  onReauthenticate,
+  onSeasonClosed,
+}: Props) {
+  const [readiness, setReadiness] = useState<SeasonCloseReadiness | null>(null);
+  const [selections, setSelections] = useState<Record<number, BlockerSelection>>({});
+  const [results, setResults] = useState<CloseProcessResult[]>([]);
+  const [page, setPage] = useState(1);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await fetchSeasonCloseReadiness(seasonId, page);
+      if (page > next.total_pages) {
+        setPage(next.total_pages);
+        return;
+      }
+      setReadiness(next);
+      setSelections((previous) =>
+        Object.fromEntries(
+          next.items.map((item) => [
+            item.market_id,
+            previous[item.market_id] ?? defaultBlockerSelection(item),
+          ]),
+        ),
+      );
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "준비 상태 조회에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [page, seasonId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function execute(items: CloseReadinessItem[]) {
+    if (!items.length) return;
+    if (!(await onReauthenticate())) return;
+    setLoading(true);
+    setMessage("");
+    try {
+      const processed = await processSeasonMarkets(
+        seasonId,
+        items.map((item) => {
+          const selection = selections[item.market_id] ?? defaultBlockerSelection(item);
+          return {
+            marketId: item.market_id,
+            action: selection.action,
+            result: selection.result,
+          };
+        }),
+      );
+      setResults(processed);
+      setMessage(
+        `처리 완료: 성공 ${processed.filter((item) => item.status !== "FAILURE").length}건 · 실패 ${processed.filter((item) => item.status === "FAILURE").length}건`,
+      );
+      await refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "마켓 처리에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function closeSeason() {
+    if (!(await onReauthenticate())) return;
+    if (!window.confirm("모든 차단 마켓이 해결되었습니다. 시즌을 종료할까요?")) return;
+    setLoading(true);
+    try {
+      await closeReadySeason(seasonId);
+      setMessage("시즌을 종료했습니다.");
+      await onSeasonClosed();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "시즌 종료에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function executeAll() {
+    const all = await fetchSeasonCloseReadiness(seasonId, 1, 1000);
+    await execute(all.items);
+  }
+
+  if (!readiness) {
+    return (
+      <Card className="rounded-2xl p-5">
+        <h2 className="text-xl font-bold text-black">시즌 종료 준비</h2>
+        <p className="mt-2 text-sm text-muted-foreground">불러오는 중...</p>
+      </Card>
+    );
+  }
+
+  const selectedItems = readiness.items.filter(
+    (item) => selections[item.market_id]?.selected,
+  );
+
+  return (
+    <section className="space-y-4" aria-label="시즌 종료 준비">
+      <div>
+        <h2 className="text-xl font-bold text-black">시즌 종료 준비</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          차단 마켓 {readiness.unsettled_count}건을 모두 처리해야 종료할 수 있습니다.
+        </p>
+      </div>
+      <div className="grid grid-cols-4 gap-2 text-center text-xs">
+        {(["OPEN", "CLOSED", "CANCELED", "SETTLED"] as const).map((status) => (
+          <Card key={status} className="rounded-xl p-2">
+            <p className="text-muted-foreground">{status}</p>
+            <p className="mt-1 text-lg font-bold">{readiness.status_counts[status]}</p>
+          </Card>
+        ))}
+      </div>
+      <Card
+        className={`rounded-2xl p-4 text-sm ${
+          readiness.closure_available ? "bg-green-50 text-green-700" : "bg-amber-50 text-amber-800"
+        }`}
+      >
+        {readiness.closure_available
+          ? "종료 및 다음 시즌 활성화 가능"
+          : `종료 차단: 미정산 마켓 ${readiness.unsettled_count}건`}
+      </Card>
+      <div className="grid grid-cols-2 gap-2">
+        <Button
+          variant="outline"
+          className="h-12"
+          onClick={() => void downloadSeasonCloseCsv(seasonId)}
+        >
+          CSV 다운로드
+        </Button>
+        <Button
+          className="h-12"
+          disabled={!readiness.closure_available || loading}
+          onClick={() => void closeSeason()}
+        >
+          시즌 종료 확정
+        </Button>
+      </div>
+      {readiness.items.map((item) => (
+        <SeasonBlockerCard
+          key={item.market_id}
+          item={item}
+          selection={selections[item.market_id] ?? defaultBlockerSelection(item)}
+          onChange={(selection) =>
+            setSelections((previous) => ({ ...previous, [item.market_id]: selection }))
+          }
+        />
+      ))}
+      {readiness.items.length ? (
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            variant="outline"
+            className="h-12"
+            disabled={!selectedItems.length || loading}
+            onClick={() => void execute(selectedItems)}
+          >
+            선택 실행
+          </Button>
+          <Button
+            className="h-12"
+            disabled={loading}
+            onClick={() => void executeAll()}
+          >
+            모든 차단 마켓 처리
+          </Button>
+        </div>
+      ) : null}
+      <div className="flex items-center justify-between text-sm">
+        <Button
+          variant="ghost"
+          disabled={page <= 1}
+          onClick={() => setPage((value) => value - 1)}
+        >
+          이전
+        </Button>
+        <span>{page} / {readiness.total_pages}</span>
+        <Button
+          variant="ghost"
+          disabled={page >= readiness.total_pages}
+          onClick={() => setPage((value) => value + 1)}
+        >
+          다음
+        </Button>
+      </div>
+      {message ? <p role="status" className="rounded-lg bg-slate-100 p-3 text-sm">{message}</p> : null}
+      {results.length ? (
+        <div className="space-y-1 text-xs">
+          {results.map((result, index) => (
+            <p key={`${result.market_id}-${index}`}>
+              #{result.market_id} {result.action} · {result.status} · {result.message}
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/lib/admin/season-close-client.ts
+++ b/lib/admin/season-close-client.ts
@@ -1,0 +1,143 @@
+export type CloseAction = "CLOSE" | "SETTLE" | "CANCEL";
+export type SettlementResult = "HOME" | "AWAY" | "DRAW";
+
+export type CloseReadinessItem = Readonly<{
+  market_id: number;
+  market_status: "OPEN" | "CLOSED";
+  game_id: number;
+  game_date: string;
+  game_status: string;
+  home_score: number | null;
+  away_score: number | null;
+  position_holder_count: number;
+  classification:
+    | "AUTO_DECIDABLE"
+    | "MANUAL_REVIEW"
+    | "CANCELLATION_RECOMMENDED";
+  proposed_result: SettlementResult | null;
+  estimated_payout: number;
+  estimated_refund: number;
+  eligible_actions: CloseAction[];
+}>;
+
+export type SeasonCloseReadiness = Readonly<{
+  season_id: number;
+  season_name: string;
+  season_status: string;
+  status_counts: Record<"OPEN" | "CLOSED" | "CANCELED" | "SETTLED", number>;
+  unsettled_count: number;
+  closure_available: boolean;
+  next_activation_available: boolean;
+  page: number;
+  page_size: number;
+  total_pages: number;
+  items: CloseReadinessItem[];
+}>;
+
+export type CloseProcessItem = Readonly<{
+  marketId: number;
+  action: CloseAction;
+  result?: SettlementResult;
+}>;
+
+export type CloseProcessResult = Readonly<{
+  market_id: number;
+  action: CloseAction;
+  result: SettlementResult | null;
+  status: "SUCCESS" | "FAILURE" | "SKIPPED";
+  message: string;
+}>;
+
+async function readJson<T>(response: Response): Promise<T> {
+  const body = (await response.json()) as T & { error?: string };
+  if (!response.ok) {
+    throw new Error(body.error ?? "시즌 종료 준비 요청에 실패했습니다.");
+  }
+  return body;
+}
+
+export async function fetchSeasonCloseReadiness(
+  seasonId: number,
+  page: number,
+  pageSize = 2,
+): Promise<SeasonCloseReadiness> {
+  const params = new URLSearchParams({
+    seasonId: String(seasonId),
+    page: String(page),
+    pageSize: String(pageSize),
+  });
+  const response = await fetch(`/api/admin/season-close?${params}`, {
+    credentials: "same-origin",
+    cache: "no-store",
+  });
+  return (await readJson<{ readiness: SeasonCloseReadiness }>(response))
+    .readiness;
+}
+
+async function mutate<T>(
+  action: "process" | "close",
+  input: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch("/api/admin/season-close", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, ...input }),
+  });
+  return readJson<T>(response);
+}
+
+export async function processSeasonMarkets(
+  seasonId: number,
+  items: readonly CloseProcessItem[],
+): Promise<CloseProcessResult[]> {
+  return (
+    await mutate<{ results: CloseProcessResult[] }>("process", {
+      seasonId,
+      items,
+    })
+  ).results;
+}
+
+export async function closeReadySeason(seasonId: number): Promise<void> {
+  await mutate("close", { seasonId });
+}
+
+function csvCell(value: unknown): string {
+  return `"${String(value ?? "").replaceAll('"', '""')}"`;
+}
+
+export async function downloadSeasonCloseCsv(seasonId: number) {
+  const readiness = await fetchSeasonCloseReadiness(seasonId, 1, 1000);
+  const rows = [
+    [
+      "market_id",
+      "game_date",
+      "game_status",
+      "market_status",
+      "classification",
+      "proposed_result",
+      "position_holders",
+      "estimated_payout",
+      "estimated_refund",
+    ],
+    ...readiness.items.map((item) => [
+      item.market_id,
+      item.game_date,
+      item.game_status,
+      item.market_status,
+      item.classification,
+      item.proposed_result ?? "",
+      item.position_holder_count,
+      item.estimated_payout,
+      item.estimated_refund,
+    ]),
+  ];
+  const csv = `\uFEFF${rows.map((row) => row.map(csvCell).join(",")).join("\n")}`;
+  const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8" }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `season-${seasonId}-close-readiness.csv`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/supabase/migrations/20260802000040_season_close_readiness.sql
+++ b/supabase/migrations/20260802000040_season_close_readiness.sql
@@ -1,0 +1,403 @@
+-- Issue #40: season close readiness, impact preview, and idempotent bulk processing.
+
+create or replace function public.get_season_close_readiness(
+  p_season_id integer,
+  p_page integer default 1,
+  p_page_size integer default 20
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_season public.seasons;
+  v_page integer := greatest(coalesce(p_page, 1), 1);
+  v_page_size integer := least(greatest(coalesce(p_page_size, 20), 1), 1000);
+  v_unsettled integer;
+  v_items jsonb;
+begin
+  select *
+  into v_season
+  from public.seasons
+  where id = p_season_id;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+
+  select count(*)
+  into v_unsettled
+  from public.markets
+  where season_id = p_season_id
+    and status in ('OPEN', 'CLOSED');
+
+  select coalesce(jsonb_agg(to_jsonb(rows) order by rows.game_date, rows.market_id), '[]'::jsonb)
+  into v_items
+  from (
+    select
+      m.id as market_id,
+      m.status::text as market_status,
+      g.id as game_id,
+      g.game_date,
+      g.game_status::text as game_status,
+      g.home_score,
+      g.away_score,
+      (
+        select count(distinct p.user_id)
+        from public.positions p
+        where p.market_id = m.id and p.quantity > 0
+      )::integer as position_holder_count,
+      case
+        when g.game_status = 'CANCELED' then 'CANCELLATION_RECOMMENDED'
+        when g.game_status = 'FINISHED'
+          and g.home_score is not null
+          and g.away_score is not null then 'AUTO_DECIDABLE'
+        else 'MANUAL_REVIEW'
+      end as classification,
+      case
+        when g.game_status = 'FINISHED'
+          and g.home_score is not null
+          and g.away_score is not null
+          and g.home_score > g.away_score then 'HOME'
+        when g.game_status = 'FINISHED'
+          and g.home_score is not null
+          and g.away_score is not null
+          and g.home_score < g.away_score then 'AWAY'
+        when g.game_status = 'FINISHED'
+          and g.home_score is not null
+          and g.away_score is not null then 'DRAW'
+        else null
+      end as proposed_result,
+      coalesce((
+        select sum(p.quantity * 100)
+        from public.positions p
+        where p.market_id = m.id
+          and p.quantity > 0
+          and p.outcome = case
+            when g.game_status = 'FINISHED'
+              and g.home_score > g.away_score then 'HOME'
+            when g.game_status = 'FINISHED'
+              and g.home_score < g.away_score then 'AWAY'
+            when g.game_status = 'FINISHED' then 'DRAW'
+            else ''
+          end
+      ), 0) as estimated_payout,
+      coalesce((
+        select sum(p.quantity * p.avg_entry_price)
+        from public.positions p
+        where p.market_id = m.id and p.quantity > 0
+      ), 0) as estimated_refund,
+      case
+        when g.game_status = 'CANCELED' then array['CANCEL']::text[]
+        when m.status = 'OPEN' then array['CLOSE', 'SETTLE', 'CANCEL']::text[]
+        else array['SETTLE', 'CANCEL']::text[]
+      end as eligible_actions
+    from public.markets m
+    join public.games g on g.id = m.game_id
+    where m.season_id = p_season_id
+      and m.status in ('OPEN', 'CLOSED')
+    order by g.game_date, m.id
+    offset (v_page - 1) * v_page_size
+    limit v_page_size
+  ) rows;
+
+  return jsonb_build_object(
+    'season_id', v_season.id,
+    'season_name', v_season.name,
+    'season_status', v_season.status,
+    'status_counts', jsonb_build_object(
+      'OPEN', (
+        select count(*) from public.markets
+        where season_id = p_season_id and status = 'OPEN'
+      ),
+      'CLOSED', (
+        select count(*) from public.markets
+        where season_id = p_season_id and status = 'CLOSED'
+      ),
+      'CANCELED', (
+        select count(*) from public.markets
+        where season_id = p_season_id and status = 'CANCELED'
+      ),
+      'SETTLED', (
+        select count(*) from public.markets
+        where season_id = p_season_id and status = 'SETTLED'
+      )
+    ),
+    'unsettled_count', v_unsettled,
+    'closure_available', v_season.status = 'ACTIVE' and v_unsettled = 0,
+    'next_activation_available', v_unsettled = 0,
+    'page', v_page,
+    'page_size', v_page_size,
+    'total_pages', greatest(ceil(v_unsettled::numeric / v_page_size)::integer, 1),
+    'items', v_items
+  );
+end;
+$$;
+
+create or replace function public.admin_process_season_markets(
+  p_operator_id uuid,
+  p_season_id integer,
+  p_items jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_season public.seasons;
+  v_item jsonb;
+  v_market public.markets;
+  v_game public.games;
+  v_market_id integer;
+  v_action text;
+  v_result text;
+  v_rpc jsonb;
+  v_before jsonb;
+  v_after jsonb;
+  v_results jsonb := '[]'::jsonb;
+  v_before_rows jsonb := '[]'::jsonb;
+  v_after_rows jsonb := '[]'::jsonb;
+  v_success_count integer := 0;
+  v_failure_count integer := 0;
+  v_outcome_status text;
+  v_message text;
+begin
+  select *
+  into v_season
+  from public.seasons
+  where id = p_season_id
+  for update;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_season.status <> 'ACTIVE' then
+    raise exception 'ACTIVE 시즌의 마켓만 처리할 수 있습니다';
+  end if;
+  if p_items is null
+    or jsonb_typeof(p_items) <> 'array'
+    or jsonb_array_length(p_items) = 0 then
+    raise exception '처리할 마켓을 선택해주세요';
+  end if;
+
+  for v_item in select value from jsonb_array_elements(p_items)
+  loop
+    v_market_id := nullif(v_item->>'market_id', '')::integer;
+    v_action := upper(btrim(coalesce(v_item->>'action', '')));
+    v_result := upper(btrim(coalesce(v_item->>'result', '')));
+    v_before := null;
+    v_after := null;
+    v_rpc := null;
+    v_outcome_status := 'SUCCESS';
+    v_message := '처리 완료';
+
+    begin
+      if v_action not in ('CLOSE', 'SETTLE', 'CANCEL') then
+        raise exception '지원하지 않는 처리 작업입니다';
+      end if;
+
+      select *
+      into v_market
+      from public.markets
+      where id = v_market_id and season_id = p_season_id
+      for update;
+
+      if not found then
+        raise exception '시즌에 속한 마켓을 찾을 수 없습니다';
+      end if;
+
+      select *
+      into v_game
+      from public.games
+      where id = v_market.game_id;
+
+      v_before := to_jsonb(v_market);
+      v_before_rows := v_before_rows || jsonb_build_array(v_before);
+
+      if v_action = 'CLOSE' and v_market.status = 'CLOSED' then
+        v_outcome_status := 'SKIPPED';
+        v_message := '이미 종료된 마켓입니다';
+      elsif v_action = 'SETTLE' and v_market.status = 'SETTLED' then
+        v_outcome_status := 'SKIPPED';
+        v_message := '이미 정산된 마켓입니다';
+      elsif v_action = 'CANCEL' and v_market.status = 'CANCELED' then
+        v_outcome_status := 'SKIPPED';
+        v_message := '이미 취소된 마켓입니다';
+      elsif v_market.status in ('SETTLED', 'CANCELED') then
+        raise exception '완료된 마켓에는 다른 작업을 실행할 수 없습니다';
+      elsif v_game.game_status = 'CANCELED' and v_action <> 'CANCEL' then
+        raise exception '취소 경기는 CANCEL만 실행할 수 있습니다';
+      elsif v_action = 'CLOSE' then
+        v_rpc := public.close_market(v_market.id);
+        if not coalesce((v_rpc->>'success')::boolean, false) then
+          raise exception '%', coalesce(v_rpc->>'error', '마켓 종료 실패');
+        end if;
+      elsif v_action = 'CANCEL' then
+        v_rpc := public.cancel_market(v_market.id);
+        if not coalesce((v_rpc->>'success')::boolean, false) then
+          raise exception '%', coalesce(v_rpc->>'error', '마켓 취소 실패');
+        end if;
+      else
+        if v_result not in ('HOME', 'AWAY', 'DRAW') then
+          if v_game.game_status = 'FINISHED'
+            and v_game.home_score is not null
+            and v_game.away_score is not null then
+            v_result := case
+              when v_game.home_score > v_game.away_score then 'HOME'
+              when v_game.home_score < v_game.away_score then 'AWAY'
+              else 'DRAW'
+            end;
+          else
+            raise exception '수동 검토 마켓은 정산 결과를 선택해야 합니다';
+          end if;
+        end if;
+
+        if v_market.status = 'OPEN' then
+          v_rpc := public.close_market(v_market.id);
+          if not coalesce((v_rpc->>'success')::boolean, false) then
+            raise exception '%', coalesce(v_rpc->>'error', '마켓 종료 실패');
+          end if;
+        end if;
+
+        v_rpc := public.settle_market(v_market.id, v_result);
+        if not coalesce((v_rpc->>'success')::boolean, false) then
+          raise exception '%', coalesce(v_rpc->>'error', '마켓 정산 실패');
+        end if;
+      end if;
+
+      select to_jsonb(m)
+      into v_after
+      from public.markets m
+      where m.id = v_market_id;
+      v_after_rows := v_after_rows || jsonb_build_array(v_after);
+      v_success_count := v_success_count + 1;
+    exception
+      when others then
+        v_outcome_status := 'FAILURE';
+        v_message := sqlerrm;
+        select to_jsonb(m)
+        into v_after
+        from public.markets m
+        where m.id = v_market_id;
+        if v_after is not null then
+          v_after_rows := v_after_rows || jsonb_build_array(v_after);
+        end if;
+        v_failure_count := v_failure_count + 1;
+    end;
+
+    v_results := v_results || jsonb_build_array(jsonb_build_object(
+      'market_id', v_market_id,
+      'action', v_action,
+      'result', nullif(v_result, ''),
+      'status', v_outcome_status,
+      'message', v_message,
+      'before', v_before,
+      'after', v_after,
+      'rpc_result', v_rpc
+    ));
+  end loop;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_operator_id,
+    'SEASON_MARKET_BULK_PROCESS',
+    'season',
+    p_season_id::text,
+    jsonb_build_object('inputs', p_items, 'markets', v_before_rows),
+    jsonb_build_object('results', v_results, 'markets', v_after_rows),
+    v_failure_count = 0
+  );
+
+  return jsonb_build_object(
+    'season_id', p_season_id,
+    'success_count', v_success_count,
+    'failure_count', v_failure_count,
+    'results', v_results,
+    'readiness', public.get_season_close_readiness(
+      p_season_id, 1, 20
+    )
+  );
+end;
+$$;
+
+create or replace function public.admin_close_ready_season(
+  p_operator_id uuid,
+  p_season_id integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_before public.seasons;
+  v_readiness jsonb;
+  v_result jsonb;
+begin
+  select *
+  into v_before
+  from public.seasons
+  where id = p_season_id
+  for update;
+
+  if not found then
+    raise exception '시즌을 찾을 수 없습니다';
+  end if;
+  if v_before.status <> 'ACTIVE' then
+    raise exception 'ACTIVE 시즌만 종료할 수 있습니다';
+  end if;
+
+  v_readiness := public.get_season_close_readiness(
+    p_season_id, 1, 1
+  );
+  if (v_readiness->>'unsettled_count')::integer <> 0 then
+    raise exception '미정산 마켓이 남아 있어 시즌을 종료할 수 없습니다';
+  end if;
+
+  v_result := public.end_season(p_season_id);
+  if not coalesce((v_result->>'success')::boolean, false) then
+    raise exception '%', coalesce(v_result->>'error', '시즌 종료 실패');
+  end if;
+
+  insert into public.admin_audit_logs (
+    operator_id, action, target_type, target_id,
+    before_state, after_state, success
+  )
+  values (
+    p_operator_id,
+    'SEASON_CLOSE',
+    'season',
+    p_season_id::text,
+    to_jsonb(v_before),
+    v_result,
+    true
+  );
+
+  return v_result || jsonb_build_object(
+    'readiness_before_close', v_readiness
+  );
+end;
+$$;
+
+revoke all on function public.get_season_close_readiness(
+  integer, integer, integer
+) from public, anon, authenticated;
+revoke all on function public.admin_process_season_markets(
+  uuid, integer, jsonb
+) from public, anon, authenticated;
+revoke all on function public.admin_close_ready_season(uuid, integer)
+  from public, anon, authenticated;
+
+grant execute on function public.get_season_close_readiness(
+  integer, integer, integer
+) to service_role;
+grant execute on function public.admin_process_season_markets(
+  uuid, integer, jsonb
+) to service_role;
+grant execute on function public.admin_close_ready_season(uuid, integer)
+  to service_role;

--- a/supabase/tests/40_season_close_readiness.sql
+++ b/supabase/tests/40_season_close_readiness.sql
@@ -1,0 +1,253 @@
+begin;
+
+select plan(22);
+
+select isnt(
+  has_function_privilege(
+    'anon',
+    'public.admin_process_season_markets(uuid,integer,jsonb)',
+    'execute'
+  ),
+  true,
+  'anonymous users cannot bulk process markets'
+);
+select is(
+  (
+    public.get_season_close_readiness(1, 1, 2)
+      ->'status_counts'->>'OPEN'
+  )::integer,
+  3,
+  'readiness reports OPEN count'
+);
+select is(
+  (
+    public.get_season_close_readiness(1, 1, 2)
+      ->'status_counts'->>'CLOSED'
+  )::integer,
+  1,
+  'readiness reports CLOSED count'
+);
+select is(
+  (
+    public.get_season_close_readiness(1, 1, 2)
+      ->>'unsettled_count'
+  )::integer,
+  4,
+  'readiness reports every blocker'
+);
+select is(
+  jsonb_array_length(
+    public.get_season_close_readiness(1, 1, 2)->'items'
+  ),
+  2,
+  'readiness paginates blocking markets'
+);
+select is(
+  (
+    select item->>'classification'
+    from jsonb_array_elements(
+      public.get_season_close_readiness(1, 1, 20)->'items'
+    ) item
+    where (item->>'market_id')::integer = 4
+  ),
+  'AUTO_DECIDABLE',
+  'finished scored matches are automatically decidable'
+);
+select is(
+  (
+    select item->>'proposed_result'
+    from jsonb_array_elements(
+      public.get_season_close_readiness(1, 1, 20)->'items'
+    ) item
+    where (item->>'market_id')::integer = 4
+  ),
+  'HOME',
+  'finished scored matches include proposed result'
+);
+
+insert into public.games (
+  id, game_date, game_time, home_team_id, away_team_id,
+  home_pitcher, away_pitcher, game_status
+)
+values (
+  9940, current_date, '18:30', 1, 2, '', '', 'CANCELED'
+);
+insert into public.markets (game_id, b, season_id, status)
+values (9940, 200, 1, 'OPEN');
+
+select is(
+  (
+    select item->>'classification'
+    from jsonb_array_elements(
+      public.get_season_close_readiness(1, 1, 20)->'items'
+    ) item
+    where (item->>'game_id')::integer = 9940
+  ),
+  'CANCELLATION_RECOMMENDED',
+  'canceled games recommend cancellation'
+);
+select is(
+  (
+    select item->'eligible_actions'
+    from jsonb_array_elements(
+      public.get_season_close_readiness(1, 1, 20)->'items'
+    ) item
+    where (item->>'game_id')::integer = 9940
+  ),
+  '["CANCEL"]'::jsonb,
+  'canceled games permit only cancellation'
+);
+
+insert into public.positions (
+  user_id, market_id, outcome, quantity, avg_entry_price, season_id
+)
+values (
+  (select id from public.users order by student_number limit 1),
+  4,
+  'HOME',
+  2,
+  30,
+  1
+);
+
+select is(
+  (
+    select (item->>'position_holder_count')::integer
+    from jsonb_array_elements(
+      public.get_season_close_readiness(1, 1, 20)->'items'
+    ) item
+    where (item->>'market_id')::integer = 4
+  ),
+  1,
+  'readiness previews affected position holders'
+);
+select is(
+  (
+    select (item->>'estimated_payout')::numeric
+    from jsonb_array_elements(
+      public.get_season_close_readiness(1, 1, 20)->'items'
+    ) item
+    where (item->>'market_id')::integer = 4
+  ),
+  200::numeric,
+  'readiness estimates settlement payout'
+);
+
+select is(
+  (
+    public.admin_process_season_markets(
+      null,
+      1,
+      jsonb_build_array(
+        jsonb_build_object(
+          'market_id', 4, 'action', 'SETTLE', 'result', 'HOME'
+        ),
+        jsonb_build_object(
+          'market_id', 999999, 'action', 'CLOSE'
+        )
+      )
+    )->>'success_count'
+  )::integer,
+  1,
+  'bulk processing reports successful items'
+);
+select is(
+  (
+    select count(*)::integer
+    from public.transactions
+    where reference_id = 4
+      and description = '마켓 정산 - HOME'
+  ),
+  1,
+  'settlement creates one payout record'
+);
+select is(
+  (
+    public.admin_process_season_markets(
+      null,
+      1,
+      jsonb_build_array(
+        jsonb_build_object(
+          'market_id', 4, 'action', 'SETTLE', 'result', 'HOME'
+        )
+      )
+    )->'results'->0->>'status'
+  ),
+  'SKIPPED',
+  'repeated settlement is idempotently skipped'
+);
+select is(
+  (
+    select count(*)::integer
+    from public.transactions
+    where reference_id = 4
+      and description = '마켓 정산 - HOME'
+  ),
+  1,
+  'repeated settlement does not duplicate payouts'
+);
+
+select lives_ok(
+  $$select public.admin_process_season_markets(
+    null,
+    1,
+    jsonb_build_array(
+      jsonb_build_object('market_id', 1, 'action', 'CANCEL'),
+      jsonb_build_object('market_id', 2, 'action', 'CANCEL'),
+      jsonb_build_object('market_id', 3, 'action', 'CANCEL'),
+      jsonb_build_object(
+        'market_id',
+        (select id from public.markets where game_id = 9940),
+        'action',
+        'CANCEL'
+      )
+    )
+  )$$,
+  'remaining blockers can be canceled in one batch'
+);
+select is(
+  (
+    public.get_season_close_readiness(1, 1, 20)
+      ->>'unsettled_count'
+  )::integer,
+  0,
+  'readiness clears only after every blocker is resolved'
+);
+select ok(
+  (
+    public.get_season_close_readiness(1, 1, 20)
+      ->>'closure_available'
+  )::boolean,
+  'season closure is available at zero blockers'
+);
+select lives_ok(
+  $$select public.admin_close_ready_season(null, 1)$$,
+  'ready season can be closed'
+);
+select is(
+  (select status::text from public.seasons where id = 1),
+  'ARCHIVED',
+  'closing transitions the active season to archived'
+);
+select ok(
+  exists (
+    select 1
+    from public.admin_audit_logs
+    where action = 'SEASON_MARKET_BULK_PROCESS'
+      and before_state ? 'inputs'
+      and after_state ? 'results'
+  ),
+  'bulk executions audit inputs, targets, and results'
+);
+select ok(
+  exists (
+    select 1
+    from public.admin_audit_logs
+    where action = 'SEASON_CLOSE'
+  ),
+  'season closure is audit logged'
+);
+
+select * from finish();
+
+rollback;

--- a/tests/admin/issue-40.test.ts
+++ b/tests/admin/issue-40.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { createLocalServiceClient } from "@/tests/helpers/local-supabase";
+
+describe("issue #40 season close readiness", () => {
+  it("classifies every blocking market for governed bulk processing", async () => {
+    const service = createLocalServiceClient();
+    const readiness = await service.rpc("get_season_close_readiness", {
+      p_season_id: 1,
+      p_page: 1,
+      p_page_size: 20,
+    });
+
+    expect(readiness.error).toBeNull();
+    expect(readiness.data).toBeTruthy();
+  });
+});

--- a/tests/e2e/admin-ops.spec.ts
+++ b/tests/e2e/admin-ops.spec.ts
@@ -149,3 +149,88 @@ test("draft season policy management is available @issue-39", async ({
     fullPage: true,
   });
 });
+
+test("season close readiness processing is available @issue-40", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/admin");
+  await page.getByPlaceholder("운영자 아이디").fill("owner");
+  await page.getByPlaceholder("운영자 비밀번호").fill("OwnerPass!234");
+  await page.getByRole("button", { name: "로그인" }).click();
+
+  const service = createLocalServiceClient();
+  const canceledBlocker = await service
+    .from("markets")
+    .update({ status: "OPEN" })
+    .eq("id", 5);
+  expect(canceledBlocker.error).toBeNull();
+
+  const seasonCard = page
+    .getByRole("heading", { name: "시즌 관리" })
+    .locator("..");
+  await seasonCard.getByRole("button", { name: "접속" }).click();
+  await expect(
+    page.getByRole("heading", { name: "시즌 종료 준비" }),
+  ).toBeVisible();
+
+  await expect(page.getByText("종료 차단: 미정산 마켓 5건")).toBeVisible();
+  await expect(page.getByText("1 / 3")).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "CSV 다운로드" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe(
+    "season-1-close-readiness.csv",
+  );
+
+  await page.getByRole("button", { name: "다음" }).click();
+  await page.getByRole("button", { name: "다음" }).click();
+  const canceledCard = page.getByLabel("마켓 5");
+  await expect(canceledCard.getByText("취소 권장")).toBeVisible();
+  await expect(
+    canceledCard.getByLabel("마켓 5 작업").locator("option"),
+  ).toHaveCount(1);
+
+  page.on("dialog", async (dialog) => {
+    await dialog.accept(
+      dialog.type() === "prompt" ? "OwnerPass!234" : undefined,
+    );
+  });
+  await page.getByRole("button", { name: "모든 차단 마켓 처리" }).click();
+  await expect(
+    page.getByText("처리 완료: 성공 5건 · 실패 0건"),
+  ).toBeVisible();
+  await expect(page.getByText("종료 차단: 미정산 마켓 3건")).toBeVisible();
+
+  await page.getByRole("button", { name: "모든 차단 마켓 처리" }).click();
+  await expect(
+    page.getByText("처리 완료: 성공 3건 · 실패 0건"),
+  ).toBeVisible();
+  await expect(page.getByText("종료 및 다음 시즌 활성화 가능")).toBeVisible();
+
+  await page.screenshot({
+    path: testInfo.outputPath("issue-40-close-ready-console.png"),
+    fullPage: true,
+  });
+
+  const closeButton = page.getByRole("button", { name: "시즌 종료 확정" });
+  await expect(closeButton).toBeEnabled();
+  await closeButton.click();
+  await expect(
+    page.getByLabel("Season 1 시즌").getByText("ARCHIVED", { exact: true }),
+  ).toBeVisible();
+
+  const audit = await service
+    .from("admin_audit_logs")
+    .select("action")
+    .in("action", ["SEASON_MARKET_BULK_PROCESS", "SEASON_CLOSE"]);
+  expect(audit.error).toBeNull();
+  expect(
+    new Set(audit.data?.map((row) => row.action)),
+  ).toEqual(new Set(["SEASON_MARKET_BULK_PROCESS", "SEASON_CLOSE"]));
+
+  await page.screenshot({
+    path: testInfo.outputPath("issue-40-season-close-readiness.png"),
+    fullPage: true,
+  });
+});


### PR DESCRIPTION
## 요약
- 시즌별 OPEN/CLOSED/CANCELED/SETTLED 집계와 모든 종료 차단 마켓 페이지네이션 추가
- 경기/마켓 상태·스코어·보유자·예상 지급/환급을 바탕으로 자동 판정/수동 검토/취소 권장 분류
- 선택 또는 전체 CLOSE/SETTLE/CANCEL 실행과 항목별 성공/실패/스킵 결과 제공
- 반복 실행 시 중복 정산·환급을 막는 idempotent terminal-state 처리
- 차단 0건에서만 시즌 종료 및 다음 시즌 활성화 가능 표시·종료 실행
- 전체 close-check CSV 다운로드와 입력/전후/결과 감사 로그 추가

## 검증
- `npm run test:unit` (5 tests)
- `npm run test:db` (58 pgTAP assertions)
- `npx playwright test tests/e2e/admin-ops.spec.ts --grep "@issue-40"`
- `npm run typecheck`
- `npm run build:local`
- 5개 차단 마켓을 두 번의 일괄 실행으로 0건 처리 후 시즌 ARCHIVED 확인
- 최종 로컬 DB 3 users / 1 ACTIVE / 4 blockers 복원, port 3000 해제

## DB 안전
모든 마이그레이션·RPC·브라우저 검증은 `127.0.0.1` 로컬 Supabase에서만 수행했습니다. 운영 DB에는 어떤 수정도 하지 않았습니다.

## 의존성
- Stacked on #51 (`feat/admin-ops-39-draft-seasons`)

Closes #40